### PR TITLE
Bsapp 485 bug db mig

### DIFF
--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V1038__insert_mannschaftsmitglied.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V1038__insert_mannschaftsmitglied.sql
@@ -13,10 +13,6 @@
 -- und je Disziplin in einem anderen Verein in einer Mannschaft sein...
 
 
-SET search_path = 'prod_data_migration'
-;
-
-
 
 DELETE from mannschaftsmitglied;
 

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V1041__insert_lizenz.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V1041__insert_lizenz.sql
@@ -1,8 +1,8 @@
 
 
-
 -- Migration Tabelle "lizenzneutabelle" -- macht keinen Sinn, da steht nichts drin
 -- wir gegenerieren hier eine Lizenz für alle Mannschaftsmitglieder
+-- 999999999999S = 5 Stellen für region_id, 6 Stellen für dsb_mitglied_id, 1 Stelle für die 0
 
 
 DELETE from lizenz;
@@ -15,16 +15,16 @@ insert INTO lizenz
     lizenz_disziplin_id
     )
 SELECT
-  to_number((verein_region_id || '0' || mannschaftsmitglied.mannschaftsmitglied_dsb_mitglied_id), '999D99S') ,
-  verein.verein_region_id,
-   mannschaftsmitglied.mannschaftsmitglied_dsb_mitglied_id,
-    'Liga',
-    '0'
-from
-  verein,
-  mannschaft,
-  mannschaftsmitglied
+       to_number(TRIM(LEADING '0' FROM (CAST(verein_region_id AS TEXT))) || '0' ||
+                 TRIM(LEADING '0' FROM (CAST(mannschaftsmitglied.mannschaftsmitglied_dsb_mitglied_id AS TEXT))),
+                 '999999999999S'),
+       verein.verein_region_id,
+       mannschaftsmitglied.mannschaftsmitglied_dsb_mitglied_id,
+       'Liga',
+       '0'
+from verein,
+     mannschaft,
+     mannschaftsmitglied
 where verein.verein_id = mannschaft.mannschaft_verein_id
-and mannschaftsmitglied.mannschaftsmitglied_mannschaft_id = mannschaft.mannschaft_id
+  and mannschaftsmitglied.mannschaftsmitglied_mannschaft_id = mannschaft.mannschaft_id
 ;
-

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V64__rolle_recht__insert.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/PROD-DATA-MIGRATION/V64__rolle_recht__insert.sql
@@ -22,5 +22,5 @@ VALUES (1, 0), -- admin = all permissions (technical and business)
        (1, 14),
        (1, 15),
        (1, 16),
-       (2, 0) -- DEFAULT
+       (8, 0) -- DEFAULT
  ;


### PR DESCRIPTION
Fehler in den Prod Migrations SQL-Dateien behoben.
- Searchpath der Mannschaftsmitglieder entfernt
- Number-Overflow des Lizenz-Statements behoben. Lizenznummer von RegionID+0+.+DsbMitglied ID zu RegionID(5 Stellen)+0+DsbMitglied ID (6 Stellen) geändert
- Ligadefault: Zuordnung in der Rolle_Recht-Tabelle war falsch