### PR TITLE
Bsapp 547

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
@@ -186,6 +186,9 @@ public class DownloadService implements ServiceFacade {
      * return the Rueckennummern as pdf file for client download
      *
      * @param mannschaftid from GET-request: ID of the mannschaft
+     * Usage:
+     * <pre>{@code Request: GET /v1/download/pdf/rueckennummern?mannschaftid=x}</pre>
+     *
      * @return pdf as InputStreamRessource
      */
     @CrossOrigin(maxAge = 0)

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
@@ -212,7 +212,7 @@ public class DownloadService implements ServiceFacade {
      * @param mannschaftid from GET-request: ID of the mannschaft
      * @param dsbmitgliedid from GET-request: ID of the dsbmitglied
      * Usage:
-     * <pre>{@code Request: GET /v1/download/pdf/rueckennummer?mannschaftid=x?dsbmitgliedid=y}</pre>
+     * <pre>{@code Request: GET /v1/download/pdf/rueckennummer/?mannschaftid=x&dsbmitgliedid=y}</pre>
      *
      * @return pdf as InputStreamRessource
      */

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
@@ -25,6 +25,7 @@ import de.bogenliga.application.business.meldezettel.api.MeldezettelComponent;
 import de.bogenliga.application.business.schusszettel.api.SchusszettelComponent;
 import de.bogenliga.application.business.setzliste.api.SetzlisteComponent;
 import de.bogenliga.application.business.lizenz.api.LizenzComponent;
+import de.bogenliga.application.business.rueckennummern.api.RueckennummernComponent;
 import de.bogenliga.application.common.errorhandling.ErrorCode;
 import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
 import de.bogenliga.application.common.service.ServiceFacade;
@@ -65,6 +66,7 @@ public class DownloadService implements ServiceFacade {
     private final LizenzComponent lizenzComponent;
     private final MeldezettelComponent meldezettelComponent;
     private final BogenkontrolllisteComponent bogenkontrolllisteComponent;
+    private final RueckennummernComponent rueckennummernComponent;
 
 
     /**
@@ -74,12 +76,14 @@ public class DownloadService implements ServiceFacade {
     public DownloadService(final SetzlisteComponent setzlisteComponent, final LizenzComponent lizenzComponent,
                            final SchusszettelComponent schusszettelComponent,
                            final MeldezettelComponent meldezettelComponent,
-                           final BogenkontrolllisteComponent bogenkontrolllisteComponent) {
+                           final BogenkontrolllisteComponent bogenkontrolllisteComponent,
+                           final RueckennummernComponent rueckennummernComponent) {
         this.lizenzComponent = lizenzComponent;
         this.setzlisteComponent = setzlisteComponent;
         this.schusszettelComponent = schusszettelComponent;
         this.meldezettelComponent = meldezettelComponent;
         this.bogenkontrolllisteComponent = bogenkontrolllisteComponent;
+        this.rueckennummernComponent = rueckennummernComponent;
     }
   
     /**
@@ -173,6 +177,27 @@ public class DownloadService implements ServiceFacade {
         Preconditions.checkArgument(wettkampfid >= 0, PRECONDITION_WETTKAMPFID);
 
         final byte[] fileBloB = bogenkontrolllisteComponent.getBogenkontrolllistePDFasByteArray(wettkampfid);
+
+        return generateInputStream(fileBloB);
+    }
+
+
+    /**
+     * return the Rueckennummern as pdf file for client download
+     *
+     * @param mannschaftid from GET-request: ID of the mannschaft
+     * @return pdf as InputStreamRessource
+     */
+    @CrossOrigin(maxAge = 0)
+    @RequestMapping(method = RequestMethod.GET,
+                    path = "pdf/rueckennummern",
+                    produces = MediaType.APPLICATION_PDF_VALUE)
+    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
+    public @ResponseBody
+    ResponseEntity<InputStreamResource> downloadRueckennummernPdf(@RequestParam("mannschaftid") final long mannschaftid) {
+
+
+        final byte[] fileBloB = rueckennummernComponent.getMannschaftsRueckennummernPDFasByteArray(mannschaftid);
 
         return generateInputStream(fileBloB);
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
@@ -183,7 +183,7 @@ public class DownloadService implements ServiceFacade {
 
 
     /**
-     * return the Rueckennummern as pdf file for client download
+     * return the Rueckennummern of a mannschaft as pdf file for client download
      *
      * @param mannschaftid from GET-request: ID of the mannschaft
      * Usage:
@@ -201,6 +201,31 @@ public class DownloadService implements ServiceFacade {
 
 
         final byte[] fileBloB = rueckennummernComponent.getMannschaftsRueckennummernPDFasByteArray(mannschaftid);
+
+        return generateInputStream(fileBloB);
+    }
+
+
+    /**
+     * return the Rueckennummer of one dsbMitglied as pdf file for client download
+     *
+     * @param mannschaftid from GET-request: ID of the mannschaft
+     * @param dsbmitgliedid from GET-request: ID of the dsbmitglied
+     * Usage:
+     * <pre>{@code Request: GET /v1/download/pdf/rueckennummern?mannschaftid=x?dsbmitgliedid=y}</pre>
+     *
+     * @return pdf as InputStreamRessource
+     */
+    @CrossOrigin(maxAge = 0)
+    @RequestMapping(method = RequestMethod.GET,
+            path = "pdf/rueckennummern",
+            produces = MediaType.APPLICATION_PDF_VALUE)
+    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
+    public @ResponseBody
+    ResponseEntity<InputStreamResource> downloadRueckennummerPdf(@RequestParam("mannschaftid") final long mannschaftid,
+                                                                 @RequestParam("dsbmitgliedid") final long dsbmitgliedid) {
+
+        final byte[] fileBloB = rueckennummernComponent.getRueckennummerPDFasByteArray(mannschaftid,dsbmitgliedid);
 
         return generateInputStream(fileBloB);
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/download/DownloadService.java
@@ -212,13 +212,13 @@ public class DownloadService implements ServiceFacade {
      * @param mannschaftid from GET-request: ID of the mannschaft
      * @param dsbmitgliedid from GET-request: ID of the dsbmitglied
      * Usage:
-     * <pre>{@code Request: GET /v1/download/pdf/rueckennummern?mannschaftid=x?dsbmitgliedid=y}</pre>
+     * <pre>{@code Request: GET /v1/download/pdf/rueckennummer?mannschaftid=x?dsbmitgliedid=y}</pre>
      *
      * @return pdf as InputStreamRessource
      */
     @CrossOrigin(maxAge = 0)
     @RequestMapping(method = RequestMethod.GET,
-            path = "pdf/rueckennummern",
+            path = "pdf/rueckennummer",
             produces = MediaType.APPLICATION_PDF_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
     public @ResponseBody

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
@@ -1,0 +1,20 @@
+package de.bogenliga.application.business.rueckennummern.api;
+
+import de.bogenliga.application.common.component.ComponentFacade;
+
+/**
+ * Responsible for the rueckennummern database requests.
+ *
+ * @author Jonas Winkler, jonas.winkler@student.reutlingen-university.de
+ */
+public interface RueckennummernComponent extends ComponentFacade {
+
+    /**
+     * Generates a pdf as binary document for one selected mannschaftsmitglied
+     * @param dsbMannschaftsId ID of the mannschaft
+     * @param dsbMitgliedId ID of the dsbMitglied
+     * @return pdf as binary document
+     */
+    byte[] getRueckennummernPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId);
+
+}

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
@@ -15,7 +15,7 @@ public interface RueckennummernComponent extends ComponentFacade {
      * @param dsbMitgliedId ID of the dsbMitglied
      * @return pdf as binary document
      */
-    byte[] getRueckennummernPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId);
+    byte[] getRueckennummerPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId);
 
     /**
      * Generates a pdf as binary document for a whole mannschaft

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/api/RueckennummernComponent.java
@@ -17,4 +17,11 @@ public interface RueckennummernComponent extends ComponentFacade {
      */
     byte[] getRueckennummernPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId);
 
+    /**
+     * Generates a pdf as binary document for a whole mannschaft
+     * @param dsbMannschaftsId ID of the mannschaft
+     * @return pdf as binary document
+     */
+    byte[] getMannschaftsRueckennummernPDFasByteArray(long dsbMannschaftsId);
+
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -78,13 +78,13 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
         String Liganame = veranstaltungDO.getVeranstaltungName();
         String Verein = vereinDO.getName();
         String Schuetzenname = dsbMitgliedDO.getVorname() + ' ' + dsbMitgliedDO.getNachname();
-        String Schuetzennummer = "-1"; //später: mannschaftsmitgliedDO.getSchuetzennummer();
+        String Rueckennummer = "-1"; //später: mannschaftsmitgliedDO.getRueckennummer();
 
         List<String> Schuetzendaten = new ArrayList();
         Schuetzendaten.add(Liganame);
         Schuetzendaten.add(Verein);
         Schuetzendaten.add(Schuetzenname);
-        RueckennummerMapping.put(Schuetzennummer,Schuetzendaten);
+        RueckennummerMapping.put(Rueckennummer,Schuetzendaten);
 
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();
              PdfWriter writer = new PdfWriter(result);
@@ -121,14 +121,14 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
 
             String Verein = vereinDO.getName();
             String Schuetzenname = dsbMitgliedDO.getVorname() + ' ' + dsbMitgliedDO.getNachname();
-            String Schuetzennummer = "-1"; //später: mannschaftsmitgliedDO.getSchuetzennummer();
+            String Rueckennummer = "-1"; //später: mannschaftsmitgliedDO.getRueckennummer();
 
             List<String> Schuetzendaten = new ArrayList();
             Schuetzendaten.add(Liganame);
             Schuetzendaten.add(Verein);
             Schuetzendaten.add(Schuetzenname);
-            RueckennummerMapping.put(Schuetzennummer,Schuetzendaten);
-            LOGGER.info("Teammitglied {} mit Rückennummer {} gefunden",Schuetzenname,Schuetzennummer);
+            RueckennummerMapping.put(Rueckennummer,Schuetzendaten);
+            LOGGER.info("Teammitglied {} mit Rückennummer {} gefunden",Schuetzenname,Rueckennummer);
         }
 
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -13,6 +13,15 @@ import com.itextpdf.kernel.geom.PageSize;
 import com.itextpdf.kernel.pdf.PdfDocument;
 import com.itextpdf.kernel.pdf.PdfWriter;
 import com.itextpdf.layout.Document;
+import com.itextpdf.layout.borders.Border;
+import com.itextpdf.layout.borders.DashedBorder;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.Div;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.property.TextAlignment;
+import com.itextpdf.layout.property.UnitValue;
+import com.itextpdf.layout.property.VerticalAlignment;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
@@ -147,6 +156,52 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
     }
 
     private void generateRueckennummernDoc(Document doc, HashMap<String, List<String>> RueckennummerMapping) {
+        LOGGER.info("Es wurden {} Teams gefunden", RueckennummerMapping.size());
 
+        //Table for the entire document
+        final Table docTable = new Table(UnitValue.createPercentArray(1), true);
+        int counter=1;
+        //iterate over all Mannschaftsmitglieder
+        for(String rNummer : RueckennummerMapping.keySet()){
+            String liga = RueckennummerMapping.get(rNummer).get(0);
+            String verein = RueckennummerMapping.get(rNummer).get(1);
+            String schuetze = RueckennummerMapping.get(rNummer).get(2);
+
+            //create single RueckennummerDoc
+            final Table singleDoc = new Table(UnitValue.createPercentArray(1), true)
+                    .setBorder(Border.NO_BORDER).setVerticalAlignment(VerticalAlignment.MIDDLE);
+
+            singleDoc.setHeight(UnitValue.createPercentValue(50.0F));
+
+            if(counter % 2 == 1) {
+                singleDoc.setBorderBottom(new DashedBorder(Border.DASHED));
+            }
+
+            //fill with content of Mannschaftsmitglied
+            final Cell ligaFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.LEFT)
+                    .add(new Paragraph(liga).setFontSize(10.0F));
+            final Cell vereinFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.LEFT)
+                    .add(new Paragraph(verein).setFontSize(10.0F));
+            final Cell schuetzeFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.CENTER)
+                    .add(new Paragraph(schuetze).setBold().setFontSize(25.0F));
+            final Cell rueckenNrFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.CENTER)
+                    .add(new Paragraph(rNummer).setBold().setFontSize(50.0F));
+
+            singleDoc
+                    .addCell(ligaFeld)
+                    .addCell(vereinFeld)
+                    .addCell(schuetzeFeld)
+                    .addCell(rueckenNrFeld);
+
+            docTable.addCell(singleDoc);
+
+            counter++;
+        }
+
+        //Add document table to document
+        doc.add(new Div().setPaddings(10.0F, 10.0F, 0.0F, 10.0F).setBorder(Border.NO_BORDER)
+                        .add(docTable).setBorder(Border.NO_BORDER));
+
+        doc.close();
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -87,7 +87,7 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
         String Liganame = veranstaltungDO.getVeranstaltungName();
         String Verein = vereinDO.getName();
         String Schuetzenname = dsbMitgliedDO.getVorname() + ' ' + dsbMitgliedDO.getNachname();
-        String Rueckennummer = "-1"; //später: mannschaftsmitgliedDO.getRueckennummer();
+        String Rueckennummer = "1"; //später: mannschaftsmitgliedDO.getRueckennummer();
 
         List<String> Schuetzendaten = new ArrayList();
         Schuetzendaten.add(Liganame);
@@ -124,7 +124,7 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
 
         String Liganame = veranstaltungDO.getVeranstaltungName();
 
-        int nr = -1; //temporary
+        int nr = 1; //temporary
 
         for(MannschaftsmitgliedDO mannschaftsmitgliedDO : mannschaftsmitgliedDOs) {
             DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(mannschaftsmitgliedDO.getDsbMitgliedId());
@@ -140,7 +140,7 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
             Schuetzendaten.add(Schuetzenname);
             RueckennummerMapping.put(Rueckennummer,Schuetzendaten);
             LOGGER.info("Teammitglied {} mit Rückennummer {} gefunden",Schuetzenname,Rueckennummer);
-            nr--; //temporary
+            nr++; //temporary
         }
 
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -174,9 +174,9 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
             final Table singleDoc = new Table(UnitValue.createPercentArray(1), true)
                     .setBorder(Border.NO_BORDER)
                     .setMargins(50F,50F,50F,50F);
-            final Table test=new Table(UnitValue.createPercentArray(1),true)
+            final Table veranstaltung=new Table(UnitValue.createPercentArray(1),true)
                     .setBorder(Border.NO_BORDER);
-            final Table test2=new Table(UnitValue.createPercentArray(1),true)
+            final Table schuetzenInfo=new Table(UnitValue.createPercentArray(1),true)
                     .setBorder(Border.NO_BORDER).setVerticalAlignment(VerticalAlignment.MIDDLE);
 
             float totalMargin=singleDoc.getMarginTop().getValue()+singleDoc.getMarginBottom().getValue();
@@ -193,16 +193,16 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
             final Cell rueckenNrFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.CENTER)
                     .add(new Paragraph(rNummer).setBold().setFontSize(100.0F));
 
-            test
+            veranstaltung
                     .addCell(ligaFeld)
                     .addCell(vereinFeld);
-            test2
+            schuetzenInfo
                     .addCell(schuetzeFeld)
                     .addCell(rueckenNrFeld);
             singleDoc.addCell(new Cell().setBorder(Border.NO_BORDER)
-                            .add(test).setPaddingBottom(-50F))
+                            .add(veranstaltung).setPaddingBottom(-50F))
                     .addCell(new Cell().setBorder(Border.NO_BORDER)
-                            .add(test2));
+                            .add(schuetzenInfo));
 
             docTable.addCell(new Cell().setBorder(Border.NO_BORDER).setBorderBottom(new DashedBorder(Border.DASHED))
                     .add(singleDoc));

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -124,13 +124,15 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
 
         String Liganame = veranstaltungDO.getVeranstaltungName();
 
+        int nr = -1; //temporary
+
         for(MannschaftsmitgliedDO mannschaftsmitgliedDO : mannschaftsmitgliedDOs) {
             DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(mannschaftsmitgliedDO.getDsbMitgliedId());
             VereinDO vereinDO = this.vereinComponent.findById(dsbMitgliedDO.getVereinsId());
 
             String Verein = vereinDO.getName();
             String Schuetzenname = dsbMitgliedDO.getVorname() + ' ' + dsbMitgliedDO.getNachname();
-            String Rueckennummer = "-1"; //später: mannschaftsmitgliedDO.getRueckennummer();
+            String Rueckennummer = Integer.toString(nr); //später: mannschaftsmitgliedDO.getRueckennummer();
 
             List<String> Schuetzendaten = new ArrayList();
             Schuetzendaten.add(Liganame);
@@ -138,6 +140,7 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
             Schuetzendaten.add(Schuetzenname);
             RueckennummerMapping.put(Rueckennummer,Schuetzendaten);
             LOGGER.info("Teammitglied {} mit Rückennummer {} gefunden",Schuetzenname,Rueckennummer);
+            nr--; //temporary
         }
 
         try (ByteArrayOutputStream result = new ByteArrayOutputStream();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -62,7 +62,7 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
 
 
     @Override
-    public byte[] getRueckennummernPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId) {
+    public byte[] getRueckennummerPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId) {
 
         //Collect information
         MannschaftsmitgliedDO mannschaftsmitgliedDO = this.mannschaftsmitgliedComponent.findByMemberAndTeamId(dsbMannschaftsId, dsbMitgliedId);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -159,11 +159,11 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
     }
 
     private void generateRueckennummernDoc(Document doc, HashMap<String, List<String>> RueckennummerMapping) {
-        LOGGER.info("Es wurden {} Teams gefunden", RueckennummerMapping.size());
+        LOGGER.info("Es wurden {} Mannschaftsmitglieder gefunden", RueckennummerMapping.size());
+        doc.setMargins(0,0,0,0);
 
         //Table for the entire document
-        final Table docTable = new Table(UnitValue.createPercentArray(1), true);
-        int counter=1;
+        final Table docTable = new Table(UnitValue.createPercentArray(1), true).setBorder(Border.NO_BORDER);
         //iterate over all Mannschaftsmitglieder
         for(String rNummer : RueckennummerMapping.keySet()){
             String liga = RueckennummerMapping.get(rNummer).get(0);
@@ -172,13 +172,16 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
 
             //create single RueckennummerDoc
             final Table singleDoc = new Table(UnitValue.createPercentArray(1), true)
+                    .setBorder(Border.NO_BORDER)
+                    .setMargins(50F,50F,50F,50F);
+            final Table test=new Table(UnitValue.createPercentArray(1),true)
+                    .setBorder(Border.NO_BORDER);
+            final Table test2=new Table(UnitValue.createPercentArray(1),true)
                     .setBorder(Border.NO_BORDER).setVerticalAlignment(VerticalAlignment.MIDDLE);
 
-            singleDoc.setHeight(UnitValue.createPercentValue(50.0F));
+            float totalMargin=singleDoc.getMarginTop().getValue()+singleDoc.getMarginBottom().getValue();
+            singleDoc.setHeight((PageSize.A4.getHeight()-totalMargin)/2);
 
-            if(counter % 2 == 1) {
-                singleDoc.setBorderBottom(new DashedBorder(Border.DASHED));
-            }
 
             //fill with content of Mannschaftsmitglied
             final Cell ligaFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.LEFT)
@@ -188,22 +191,25 @@ public class RueckennummernComponentImpl implements RueckennummernComponent {
             final Cell schuetzeFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.CENTER)
                     .add(new Paragraph(schuetze).setBold().setFontSize(25.0F));
             final Cell rueckenNrFeld = new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.CENTER)
-                    .add(new Paragraph(rNummer).setBold().setFontSize(50.0F));
+                    .add(new Paragraph(rNummer).setBold().setFontSize(100.0F));
 
-            singleDoc
+            test
                     .addCell(ligaFeld)
-                    .addCell(vereinFeld)
+                    .addCell(vereinFeld);
+            test2
                     .addCell(schuetzeFeld)
                     .addCell(rueckenNrFeld);
+            singleDoc.addCell(new Cell().setBorder(Border.NO_BORDER)
+                            .add(test).setPaddingBottom(-50F))
+                    .addCell(new Cell().setBorder(Border.NO_BORDER)
+                            .add(test2));
 
-            docTable.addCell(singleDoc);
-
-            counter++;
+            docTable.addCell(new Cell().setBorder(Border.NO_BORDER).setBorderBottom(new DashedBorder(Border.DASHED))
+                    .add(singleDoc));
         }
 
         //Add document table to document
-        doc.add(new Div().setPaddings(10.0F, 10.0F, 0.0F, 10.0F).setBorder(Border.NO_BORDER)
-                        .add(docTable).setBorder(Border.NO_BORDER));
+        doc.add(docTable);
 
         doc.close();
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/rueckennummern/impl/business/RueckennummernComponentImpl.java
@@ -1,0 +1,103 @@
+package de.bogenliga.application.business.rueckennummern.impl.business;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import com.itextpdf.kernel.geom.PageSize;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
+import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
+import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
+import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
+import de.bogenliga.application.business.mannschaftsmitglied.api.MannschaftsmitgliedComponent;
+import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
+import de.bogenliga.application.business.rueckennummern.api.RueckennummernComponent;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
+import de.bogenliga.application.business.vereine.api.VereinComponent;
+import de.bogenliga.application.business.vereine.api.types.VereinDO;
+import de.bogenliga.application.common.errorhandling.ErrorCode;
+import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
+
+/**
+ * Class to generate Rückennummer-pdf to print the labels of the teammembers for a wettkampf
+ *
+ * @author Jonas Winkler, jonas.winkler@student.reutlingen-university.de
+ */
+@Component
+public class RueckennummernComponentImpl implements RueckennummernComponent {
+
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RueckennummernComponentImpl.class);
+
+    private final MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
+    private final VereinComponent vereinComponent;
+    private final DsbMitgliedComponent dsbMitgliedComponent;
+    private final DsbMannschaftComponent dsbMannschaftComponent;
+    private final VeranstaltungComponent veranstaltungComponent;
+
+
+    @Autowired
+    public RueckennummernComponentImpl(MannschaftsmitgliedComponent mannschaftsmitgliedComponent,
+                                       VereinComponent vereinComponent,
+                                       DsbMitgliedComponent dsbMitgliedComponent,
+                                       DsbMannschaftComponent dsbMannschaftComponent,
+                                       VeranstaltungComponent veranstaltungComponent) {
+
+        this.mannschaftsmitgliedComponent = mannschaftsmitgliedComponent;
+        this.vereinComponent = vereinComponent;
+        this.dsbMitgliedComponent = dsbMitgliedComponent;
+        this.dsbMannschaftComponent = dsbMannschaftComponent;
+        this.veranstaltungComponent = veranstaltungComponent;
+    }
+
+
+
+    @Override
+    public byte[] getRueckennummernPDFasByteArray(long dsbMannschaftsId, long dsbMitgliedId) {
+
+        //Collect information
+        MannschaftsmitgliedDO mannschaftsmitgliedDO = this.mannschaftsmitgliedComponent.findByMemberAndTeamId(dsbMannschaftsId, dsbMitgliedId);
+
+        DsbMannschaftDO dsbMannschaftDO = this.dsbMannschaftComponent.findById(dsbMannschaftsId);
+        VeranstaltungDO veranstaltungDO = this.veranstaltungComponent.findById(dsbMannschaftDO.getVeranstaltungId());
+
+        DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(dsbMitgliedId);
+        VereinDO vereinDO = this.vereinComponent.findById(dsbMitgliedDO.getVereinsId());
+
+        String Liganame = veranstaltungDO.getVeranstaltungName();
+        String Verein = vereinDO.getName();
+        String Schuetzenname = dsbMitgliedDO.getVorname() + ' ' + dsbMitgliedDO.getNachname();
+        String Schuetzennummer = "-1"; //später: mannschaftsmitgliedDO.getSchuetzennummer();
+
+        try (ByteArrayOutputStream result = new ByteArrayOutputStream();
+             PdfWriter writer = new PdfWriter(result);
+             PdfDocument pdfDocument = new PdfDocument(writer);
+             Document doc = new Document(pdfDocument, PageSize.A4)) {
+
+            generateRueckennummernDoc(doc, Liganame, Verein, Schuetzenname, Schuetzennummer);
+
+            return result.toByteArray();
+
+        } catch (IOException e) {
+            throw new TechnicalException(ErrorCode.INTERNAL_ERROR,
+                    "Rueckennummern PDF konnte nicht erstellt werden: " + e);
+        }
+
+    }
+
+
+
+    private void generateRueckennummernDoc(Document doc,
+                                           String Liganame,
+                                           String Verein,
+                                           String Schuetzenname,
+                                           String Schuetzennummer) {
+
+    }
+}

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/RueckennummernComponent/impl/RueckennummernComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/RueckennummernComponent/impl/RueckennummernComponentImplTest.java
@@ -1,0 +1,129 @@
+package de.bogenliga.application.business.RueckennummernComponent.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
+import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
+import de.bogenliga.application.business.dsbmannschaft.impl.business.DsbMannschaftComponentImplTest;
+import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
+import de.bogenliga.application.business.dsbmitglied.impl.business.DsbMitgliedComponentImplTest;
+import de.bogenliga.application.business.liga.api.types.LigaDO;
+import de.bogenliga.application.business.liga.impl.business.LigaComponentImplTest;
+import de.bogenliga.application.business.mannschaftsmitglied.api.MannschaftsmitgliedComponent;
+import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.business.MannschaftsmitgliedComponentImplTest;
+import de.bogenliga.application.business.match.impl.business.MatchComponentImplTest;
+import de.bogenliga.application.business.rueckennummern.impl.business.RueckennummernComponentImpl;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.impl.business.VeranstaltungComponentImplTest;
+import de.bogenliga.application.business.vereine.api.VereinComponent;
+import de.bogenliga.application.business.vereine.api.types.VereinDO;
+import de.bogenliga.application.business.vereine.impl.business.VereinComponentImplTest;
+import de.bogenliga.application.business.wettkampf.impl.business.WettkampfComponentImplTest;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ * @author David Winkler
+ */
+public class RueckennummernComponentImplTest {
+
+    private static final long MANNSCHAFTSID = 30;
+    private static final long DSBMITGLIEDID = 30;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private DsbMannschaftComponent dsbMannschaftComponent;
+    @Mock
+    private VereinComponent vereinComponent;
+    @Mock
+    private VeranstaltungComponent veranstaltungComponent;
+    @Mock
+    private MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
+    @Mock
+    private DsbMitgliedComponent dsbMitgliedComponent;
+
+    @InjectMocks
+    private RueckennummernComponentImpl underTest;
+
+    @Test
+    public void getRueckennummerPDFasByteArray() {
+
+        //configure Mocks
+        when(vereinComponent.findById(anyLong())).thenAnswer((Answer<VereinDO>) invocation -> {
+            VereinDO ret = VereinComponentImplTest.getVereinDO();
+            ret.setName("Verein " + UUID.randomUUID());
+            return ret;
+        });
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(VeranstaltungComponentImplTest.getVeranstaltungDO());
+        when(dsbMannschaftComponent.findById(anyLong())).thenAnswer((Answer<DsbMannschaftDO>) invocation -> {
+            DsbMannschaftDO ret = DsbMannschaftComponentImplTest.getDsbMannschaftDO();
+            ret.setNummer((long)(Math.random() * 2 + 1));
+            return ret;
+        });
+        when(dsbMitgliedComponent.findById(anyLong())).thenReturn(DsbMitgliedComponentImplTest.getDsbMitgliedDO());
+
+
+        //call test method
+        final byte[] actual = underTest.getRueckennummerPDFasByteArray(MANNSCHAFTSID,DSBMITGLIEDID);
+
+        //assert
+        Assertions.assertThat(actual).isNotEmpty();
+
+        //verify invocations
+        verify(dsbMannschaftComponent, atLeastOnce()).findById(anyLong());
+        verify(veranstaltungComponent, atLeastOnce()).findById(anyLong());
+        verify(dsbMitgliedComponent, atLeastOnce()).findById(anyLong());
+        verify(vereinComponent, atLeastOnce()).findById(anyLong());
+    }
+
+    @Test
+    public void getMannschaftsRueckennummernPDFasByteArray(){
+
+        //configure Mocks
+        when(vereinComponent.findById(anyLong())).thenAnswer((Answer<VereinDO>) invocation -> {
+            VereinDO ret = VereinComponentImplTest.getVereinDO();
+            ret.setName("Verein " + UUID.randomUUID());
+            return ret;
+        });
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(VeranstaltungComponentImplTest.getVeranstaltungDO());
+        when(dsbMannschaftComponent.findById(anyLong())).thenAnswer((Answer<DsbMannschaftDO>) invocation -> {
+            DsbMannschaftDO ret = DsbMannschaftComponentImplTest.getDsbMannschaftDO();
+            ret.setNummer((long)(Math.random() * 2 + 1));
+            return ret;
+        });
+        when(dsbMitgliedComponent.findById(anyLong())).thenReturn(DsbMitgliedComponentImplTest.getDsbMitgliedDO());
+
+        List<MannschaftsmitgliedDO> mannschaftsmitgliedDOList = new ArrayList<>();
+        for(int i = 0; i < 3; i++) {
+            mannschaftsmitgliedDOList.add(MannschaftsmitgliedComponentImplTest.getMannschatfsmitgliedDO());
+        }
+        when(mannschaftsmitgliedComponent.findByTeamId(anyLong())).thenReturn(mannschaftsmitgliedDOList);
+
+
+        //call test method
+        final byte[] actual = underTest.getMannschaftsRueckennummernPDFasByteArray(MANNSCHAFTSID);
+
+        //assert
+        Assertions.assertThat(actual).isNotEmpty();
+
+        //verify invocations
+        verify(dsbMannschaftComponent, atLeastOnce()).findById(anyLong());
+        verify(mannschaftsmitgliedComponent, atLeastOnce()).findByTeamId(anyLong());
+        verify(veranstaltungComponent, atLeastOnce()).findById(anyLong());
+        verify(dsbMitgliedComponent, atLeastOnce()).findById(anyLong());
+        verify(vereinComponent, atLeastOnce()).findById(anyLong());
+    }
+}


### PR DESCRIPTION
Neue Component für das Drucken der Rückennummern als api und impl Dateien erstellt und über DownloadService mit dem Frontend verbunden (siehe pull request im frontend). Momentan ist der Branch für die neu erstellten Rückennummern noch nicht gemerged, weshalb hier noch Füllwerte eingetragen sind. Es gibt jeweils für eine gesamte Mannschaft und für einen einzelnen Schützen eine Methode, um die pdf generieren zu lassen.