### PR TITLE
Bsapp 650 dsb id benutzer

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
@@ -3,6 +3,7 @@ package de.bogenliga.application.services.v1.dsbmitglied.service;
 import java.security.Principal;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,14 +16,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
 import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
-import de.bogenliga.application.business.kampfrichter.api.KampfrichterComponent;
-import de.bogenliga.application.business.kampfrichter.api.types.KampfrichterDO;
 import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.dsbmitglied.mapper.DsbMitgliedDTOMapper;
 import de.bogenliga.application.services.v1.dsbmitglied.model.DsbMitgliedDTO;
-import de.bogenliga.application.services.v1.kampfrichter.service.KampfrichterService;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
 
@@ -141,6 +139,35 @@ public class DsbMitgliedService implements ServiceFacade {
 
         final DsbMitgliedDO dsbMitgliedDO = dsbMitgliedComponent.findById(id);
         return DsbMitgliedDTOMapper.toDTO.apply(dsbMitgliedDO);
+    }
+
+    /**
+     * I return the dsbMitglied entry of the database with a specific id.
+     *
+     * Usage:
+     * <pre>{@code Request: GET /v1/dsbmitglied/app.bogenliga.frontend.autorefresh.active}</pre>
+     * <pre>{@code Response:
+     *  {
+     *    "id": "app.bogenliga.frontend.autorefresh.active",
+     *    "value": "true"
+     *  }
+     * }
+     * </pre>
+     *
+     * @return list of {@link DsbMitgliedDTO} as JSON
+     */
+    @RequestMapping(value = "/{id}/{dsbuserid}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public DsbMitgliedDTO insertUserId(@PathVariable("id") final long id, @PathVariable("dsbuserid") final long dsbuserid, final Principal principal) {
+        Preconditions.checkArgument(id > 0, "ID must not be negative.");
+        final long userId = UserProvider.getCurrentUserId(principal);
+
+        LOG.debug("Receive 'findByDsbMitgliedId' request with ID '{}'", id);
+
+        final DsbMitgliedDO dsbMitgliedDO = dsbMitgliedComponent.findById(id);
+        dsbMitgliedDO.setUserId(dsbuserid);
+        final DsbMitgliedDO updatedDsbMitgliedDO = dsbMitgliedComponent.update(dsbMitgliedDO, userId);
+        return DsbMitgliedDTOMapper.toDTO.apply(updatedDsbMitgliedDO);
     }
 
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/user/model/UserCredentialsDTO.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/user/model/UserCredentialsDTO.java
@@ -12,6 +12,7 @@ public class UserCredentialsDTO implements DataTransferObject {
     private static final long serialVersionUID = 7100904135169446743L;
     private String username;
     private String password;
+    private Long dsb_mitglied_id;
     private String code;
     private boolean isUsing2FA;
 
@@ -29,6 +30,13 @@ public class UserCredentialsDTO implements DataTransferObject {
     }
     public void setPassword(final String password) {
         this.password = password;
+    }
+
+    public Long getDsb_mitglied_id() {
+        return dsb_mitglied_id;
+    }
+    public void setDsb_mitglied_id(final Long dsb_mitglied_id) {
+        this.dsb_mitglied_id = dsb_mitglied_id;
     }
 
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/user/service/UserService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/user/service/UserService.java
@@ -60,6 +60,7 @@ public class UserService implements ServiceFacade {
     private static final String PRECONDITION_MSG_ROLE_ID = "User Role ID must not be null or negative";
     private static final String PRECONDITION_MSG_USER_EMAIL = "Benutzer email must not be null";
     private static final String PRECONDITION_MSG_USER_PW = "This is not a valid Password";
+    private static final String PRECONDITION_MSG_DSB_MITGLIED_ID = "User must reference an existing DSB-member -not be null or negative";
 
     private static final String PW_VALIDATION_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[A-Za-z\\d#$^+=!*()@%&?]{8,}$";
 
@@ -359,12 +360,14 @@ public class UserService implements ServiceFacade {
         Preconditions.checkNotNull(userCredentialsDTO, "User Credentials must not be null");
         Preconditions.checkNotNull(userCredentialsDTO.getUsername(), PRECONDITION_MSG_USER_ID);
         Preconditions.checkNotNull(userCredentialsDTO.getPassword(), PRECONDITION_MSG_USER_EMAIL);
+        Preconditions.checkNotNull(userCredentialsDTO.getDsb_mitglied_id(), PRECONDITION_MSG_DSB_MITGLIED_ID);
         // Check if password is valid by running it against the regular expression for the password
         Preconditions.checkArgument(userCredentialsDTO.getPassword().matches(PW_VALIDATION_REGEX), PRECONDITION_MSG_USER_PW);
 
         LOG.debug("Receive 'create' request with username '{}', password '{}', using2FA {}",
                 userCredentialsDTO.getUsername(),
                 userCredentialsDTO.getPassword(),
+                userCredentialsDTO.getDsb_mitglied_id(),
                 userCredentialsDTO.isUsing2FA());
 
         userCredentialsDTO.getCode();
@@ -375,7 +378,7 @@ public class UserService implements ServiceFacade {
         // user anlegen
 
         final UserDO userCreatedDO = userComponent.create(userCredentialsDTO.getUsername(),
-                userCredentialsDTO.getPassword(), userId, userCredentialsDTO.isUsing2FA());
+                userCredentialsDTO.getPassword(), userCredentialsDTO.getDsb_mitglied_id(), userId, userCredentialsDTO.isUsing2FA());
         //default rolle anlegen (User)
         final UserRoleDO userRoleCreatedDO = userRoleComponent.create(userCreatedDO.getId(), userId);
         return UserDTOMapper.toDTO.apply(userCreatedDO);

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V308__benutzer_alter.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V308__benutzer_alter.sql
@@ -1,0 +1,38 @@
+/* Prüfen ob Gero als DSB-Mitglied eingetragen ist - falls nicht, dann ergänzen*/
+INSERT INTO dsb_mitglied (dsb_mitglied_vorname,
+                          dsb_mitglied_nachname,
+                          dsb_mitglied_geburtsdatum,
+                          dsb_mitglied_nationalitaet,
+                          dsb_mitglied_mitgliedsnummer,
+                          dsb_mitglied_verein_id)
+VALUES ('Gero', 'Gras', '1990-03-16', 'D', 'WT1009', 0)
+ON CONFLICT DO NOTHING;
+
+
+/* neue Spalte in Tabelle einfügen mit Defaul-Wert */
+ALTER TABLE benutzer
+    ADD COLUMN benutzer_dsb_mitglied_id DECIMAL(19,0) DEFAULT 0;
+
+/* Neue Spalte korrekt befüllen - im ersten Schritt sind alle existierenden Benutzer == Gero */
+UPDATE
+    benutzer
+SET
+    benutzer_dsb_mitglied_id = T2.dsb_mitglied_id
+FROM
+    dsb_mitglied T2
+WHERE
+        T2.dsb_mitglied_nachname = 'Gras'
+  AND T2.dsb_mitglied_vorname = 'Gero';
+
+/* aus der bestehender Tabelle den CONTRAIN entfernen */
+ALTER TABLE dsb_mitglied
+    DROP CONSTRAINT IF EXISTS fk_dsb_mitglied_benutzer_id;
+
+/*später muss  mal die alte Spalte in der DSB-Mitgliedstabelle bereinigt werden
+  aktuell lasse ich sie stehen um den Umbauaufwand klein zu halten. */
+
+/* in die Benutzer-Tabelle den Constrain eintragen */
+ALTER TABLE benutzer
+    ADD CONSTRAINT fk_benutzer_dsb_mitglied_id
+        FOREIGN KEY (benutzer_dsb_mitglied_id)
+            REFERENCES dsb_mitglied (dsb_mitglied_id);

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V308__benutzer_alter.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V308__benutzer_alter.sql
@@ -8,10 +8,13 @@ INSERT INTO dsb_mitglied (dsb_mitglied_vorname,
 VALUES ('Gero', 'Gras', '1990-03-16', 'D', 'WT1009', 0)
 ON CONFLICT DO NOTHING;
 
+COMMIT;
 
 /* neue Spalte in Tabelle einfügen mit Defaul-Wert */
 ALTER TABLE benutzer
     ADD COLUMN benutzer_dsb_mitglied_id DECIMAL(19,0) DEFAULT 0;
+
+COMMIT;
 
 /* Neue Spalte korrekt befüllen - im ersten Schritt sind alle existierenden Benutzer == Gero */
 UPDATE
@@ -28,6 +31,7 @@ WHERE
 ALTER TABLE dsb_mitglied
     DROP CONSTRAINT IF EXISTS fk_dsb_mitglied_benutzer_id;
 
+COMMIT;
 /*später muss  mal die alte Spalte in der DSB-Mitgliedstabelle bereinigt werden
   aktuell lasse ich sie stehen um den Umbauaufwand klein zu halten. */
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/user/service/UserServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/user/service/UserServiceTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.*;
 public class UserServiceTest {
 
     private static final Long ID = 123L;
+    private static final Long DSBMITGLIEDID = 28L;
     private static final String USERNAME = "user";
     private static final String PASSWORD = "CorrectPasswordV1";
     private static final String NEUESPASSWORD = "CorrectPasswordV2";
@@ -598,14 +599,16 @@ public class UserServiceTest {
         final UserDO userCreatedDO = new UserDO();
         userCreatedDO.setEmail(USERNAME);
         userCreatedDO.setId(ID);
+        userCreatedDO.setDsb_mitglied_id(DSBMITGLIEDID);
         userCreatedDO.setVersion(VERSION);
 
         final UserCredentialsDTO userCredentialsDTO = new UserCredentialsDTO();
         userCredentialsDTO.setUsername(USERNAME);
         userCredentialsDTO.setPassword(PASSWORD);
+        userCredentialsDTO.setDsb_mitglied_id(DSBMITGLIEDID);
 
         // configure mocks
-        when(userComponent.create(anyString(), anyString(), anyLong(), anyBoolean())).thenReturn(userCreatedDO);
+        when(userComponent.create(anyString(), anyString(), anyLong(), anyLong(), anyBoolean())).thenReturn(userCreatedDO);
         when(userRoleComponent.create(anyLong(), anyLong())).thenReturn(createdUserRoleDO);
 
         // call test method
@@ -724,6 +727,7 @@ public class UserServiceTest {
 
         final UserCredentialsDTO userCredentialsDTO = new UserCredentialsDTO();
         userCredentialsDTO.setUsername(USERNAME);
+        userCredentialsDTO.setDsb_mitglied_id(DSBMITGLIEDID);
 
         String[] invalidPasswords = new String[]{
                 "ABCabc0",

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/UserComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/UserComponent.java
@@ -60,11 +60,13 @@ public interface UserComponent extends ComponentFacade {
      *
      * @param email of the user
      * @param password of the user
+     * @param dsb_mitglied_id current user
      * @param currentUserId current user
+     *
      *
      * @return the user, if the user exists and the password is sufficient
      */
-    UserDO create(final String email, final String password, final Long currentUserId, final boolean isUsing2FA);
+    UserDO create(final String email, final String password, final Long  dsb_mitglied_id, final Long currentUserId, final boolean isUsing2FA);
 
     /**
      * Udpate password of user

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/types/UserDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/types/UserDO.java
@@ -25,6 +25,7 @@ public class UserDO extends CommonDataObject implements DataObject {
      */
     private Long id;
     private String email;
+    private Long dsb_mitglied_id;
     private boolean using2FA;
     private boolean active;
     private String secret;
@@ -39,13 +40,37 @@ public class UserDO extends CommonDataObject implements DataObject {
 
 
     /**
-     * Constructor with mandatory parameters
+     * Constructor with all parameters
      */
-    public UserDO(final Long id, final String email, boolean using2FA, boolean active, String secret, final OffsetDateTime createdAtUtc,
+    public UserDO(final Long id, final String email, final Long dsb_mitglied_id, boolean using2FA,
+                  boolean active, String secret, final OffsetDateTime createdAtUtc,
                   final Long createdByUserId, final OffsetDateTime lastModifiedAtUtc,
                   final Long lastModifiedByUserId, final Long version) {
         this.id = id;
         this.email = email;
+        this.dsb_mitglied_id = dsb_mitglied_id;
+        this.using2FA = using2FA;
+        this.active = active;
+        this.secret = secret;
+
+        // set parameter from CommonDataObject
+        this.createdAtUtc = createdAtUtc;
+        this.createdByUserId = createdByUserId;
+        this.lastModifiedAtUtc = lastModifiedAtUtc;
+        this.lastModifiedByUserId = lastModifiedByUserId;
+        this.version = version;
+    }
+
+    /**
+     * Constructor with mandatory parameters
+     */
+    public UserDO(final Long id, final String email, boolean using2FA,
+                  boolean active, String secret, final OffsetDateTime createdAtUtc,
+                  final Long createdByUserId, final OffsetDateTime lastModifiedAtUtc,
+                  final Long lastModifiedByUserId, final Long version) {
+        this.id = id;
+        this.email = email;
+        this.dsb_mitglied_id = 0L;
         this.using2FA = using2FA;
         this.active = active;
         this.secret = secret;
@@ -97,12 +122,20 @@ public class UserDO extends CommonDataObject implements DataObject {
         return getId().equals(userDO.getId()) &&
                 getVersion() == userDO.getVersion() &&
                 Objects.equals(getEmail(), userDO.getEmail()) &&
+                getDsb_mitglied_id().equals(userDO.getDsb_mitglied_id()) &&
                 Objects.equals(getCreatedAtUtc(), userDO.getCreatedAtUtc()) &&
                 Objects.equals(getCreatedByUserId(), userDO.getCreatedByUserId()) &&
                 Objects.equals(getLastModifiedAtUtc(), userDO.getLastModifiedAtUtc()) &&
                 Objects.equals(getLastModifiedByUserId(), userDO.getLastModifiedByUserId());
     }
 
+    public Long getDsb_mitglied_id() {
+        return dsb_mitglied_id;
+    }
+
+    public void setDsb_mitglied_id(final long dsb_mitglied_id) {
+        this.dsb_mitglied_id = dsb_mitglied_id;
+    }
 
     public boolean isUsing2FA() {
         return using2FA;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/types/UserWithPermissionsDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/api/types/UserWithPermissionsDO.java
@@ -59,7 +59,8 @@ public class UserWithPermissionsDO extends UserDO implements DataObject {
      */
     public UserWithPermissionsDO(final UserDO userDO,
                                  final List<String> permissions) {
-        super(userDO.getId(), userDO.getEmail(), userDO.isUsing2FA(), userDO.isActive(), userDO.getSecret(), userDO.getCreatedAtUtc(),
+        super(userDO.getId(), userDO.getEmail(), userDO.isUsing2FA(), userDO.isActive(),
+                userDO.getSecret(), userDO.getCreatedAtUtc(),
                 userDO.getCreatedByUserId(),
                 userDO.getLastModifiedAtUtc(), userDO.getLastModifiedByUserId(), userDO.getVersion());
 
@@ -87,6 +88,7 @@ public class UserWithPermissionsDO extends UserDO implements DataObject {
         return getId() == userDO.getId() &&
                 getVersion() == userDO.getVersion() &&
                 Objects.equals(getEmail(), userDO.getEmail()) &&
+                Objects.equals(getDsb_mitglied_id(), userDO.getDsb_mitglied_id()) &&
                 Objects.equals(getPermissions(), userDO.getPermissions()) &&
                 Objects.equals(getCreatedAtUtc(), userDO.getCreatedAtUtc()) &&
                 Objects.equals(getCreatedByUserId(), userDO.getCreatedByUserId()) &&

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserComponentImpl.java
@@ -27,6 +27,7 @@ public class UserComponentImpl implements UserComponent {
     private static final String PRECONDITION_MSG_USER = "UserDO must not be null";
     private static final String PRECONDITION_MSG_USER_ID = "UserDO ID must not be negative";
     private static final String PRECONDITION_MSG_USER_NULL = "UserID must not be null";
+    private static final String PRECONDITION_MSG_DSB_MITGLIED_NULL = "DSB-ID must reference a DSB member - must not be null";
     private static final String PRECONDITION_MSG_USER_EMAIL = "UserDO email must not be null or empty";
     private static final String PRECONDITON_MSG_USER_PWD = "UserDO password must not be null or empty";
     private static final String PRECONDITON_MSG_USER_WRONG_PWD = "Current password incorrect";
@@ -136,18 +137,21 @@ public class UserComponentImpl implements UserComponent {
      * Neuen User anlegen
      * @param  email User-Name
      * @param  password Kennwort
+     * @param  dsb_mitglied_id dsb-mitlgieds_bezug
      * @param  currentUserId aktueller User mit den Rechten zur Neuanlage
      */
     @Override
-    public UserDO create(final String email, final String password, final Long currentUserId, final boolean isUsing2FA) {
+    public UserDO create(final String email, final String password, final Long dsb_mitglied_id, final Long currentUserId, final boolean isUsing2FA) {
         Preconditions.checkNotNullOrEmpty(email, PRECONDITION_MSG_USER_EMAIL);
         Preconditions.checkNotNullOrEmpty(password, PRECONDITON_MSG_USER_PWD);
+        Preconditions.checkNotNull(dsb_mitglied_id, PRECONDITION_MSG_DSB_MITGLIED_NULL);
         Preconditions.checkNotNull(currentUserId, PRECONDITION_MSG_USER_NULL);
 
         final UserBE result = new UserBE();
         final String salt = passwordHashingBA.generateSalt();
         final String pwdhash = passwordHashingBA.calculateHash(password, salt);
         result.setUserEmail(email);
+        result.setDsb_mitglied_id(dsb_mitglied_id);
         result.setUserSalt(salt);
         result.setUserPassword(pwdhash);
         result.setUsing2FA(isUsing2FA);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImpl.java
@@ -48,7 +48,7 @@ public class UserProfileComponentImpl implements UserProfileComponent {
         UserProfileDO userProfileDO = new UserProfileDO();
 
         final UserBE userBE = userDAO.findById(id); // required for email adress
-        final DsbMitgliedBE dsbMitgliedBE = dsbMitgliedDAO.findByUserId(id);    // required for remaining profile data
+        final DsbMitgliedBE dsbMitgliedBE = dsbMitgliedDAO.findById(userBE.getDsb_mitglied_id());    // required for remaining profile data
 
         if (userBE == null) {
             throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND_ERROR,

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImpl.java
@@ -48,12 +48,11 @@ public class UserProfileComponentImpl implements UserProfileComponent {
         UserProfileDO userProfileDO = new UserProfileDO();
 
         final UserBE userBE = userDAO.findById(id); // required for email adress
-        final DsbMitgliedBE dsbMitgliedBE = dsbMitgliedDAO.findById(userBE.getDsb_mitglied_id());    // required for remaining profile data
-
         if (userBE == null) {
             throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND_ERROR,
                     String.format("No result found for ID '%s'", id));
         }
+        final DsbMitgliedBE dsbMitgliedBE = dsbMitgliedDAO.findById(userBE.getDsb_mitglied_id());    // required for remaining profile data
         if (dsbMitgliedBE == null) {
             userProfileDO.setEmail(userBE.getUserEmail());
         } else {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/dao/UserDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/dao/UserDAO.java
@@ -35,6 +35,7 @@ public class UserDAO implements DataAccessObject {
     private static final String USER_BE_PASSWORD = "userPassword";
     private static final String USER_BE_USING2FA = "using2FA";
     private static final String USER_BE_SECRET = "secret";
+    private static final String USER_BE_DSB_MITGLIED_ID = "dsb_mitglied_id";
 
     private static final String USER_BE_ACTIVE = "active";
 
@@ -44,6 +45,7 @@ public class UserDAO implements DataAccessObject {
     private static final String USER_TABLE_PASSWORD = "benutzer_password";
     private static final String USER_TABLE_USING2FA = "benutzer_using_2fa";
     private static final String USER_TABLE_SECRET = "benutzer_secret";
+    private static final String USER_TABLE_DSB_MITGLIED_ID = "benutzer_dsb_mitglied_id";
 
     private static final String USER_TABLE_ACTIVE = "benutzer_active";
 
@@ -95,6 +97,7 @@ public class UserDAO implements DataAccessObject {
         columnsToFieldsMap.put(USER_TABLE_USING2FA, USER_BE_USING2FA);
         columnsToFieldsMap.put(USER_TABLE_SECRET, USER_BE_SECRET);
         columnsToFieldsMap.put(USER_TABLE_ACTIVE, USER_BE_ACTIVE);
+        columnsToFieldsMap.put(USER_TABLE_DSB_MITGLIED_ID, USER_BE_DSB_MITGLIED_ID);
 
         // add technical columns
         columnsToFieldsMap.putAll(BasicDAO.getTechnicalColumnsToFieldsMap());

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/entity/UserBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/entity/UserBE.java
@@ -23,6 +23,7 @@ public class UserBE extends CommonBusinessEntity implements BusinessEntity {
     private String userEmail;
     private String userSalt;
     private String userPassword;
+    private Long dsb_mitglied_id;
     private boolean using2FA = true;
     private boolean active = true;
 
@@ -42,6 +43,7 @@ public class UserBE extends CommonBusinessEntity implements BusinessEntity {
                 ", userEmail='" + userEmail + '\'' +
                 ", userSalt='" + userSalt + '\'' +
                 ", userPassword='" + userPassword + '\'' +
+                ", dsb_mitglied_id='" + dsb_mitglied_id + '\'' +
                 '}';
     }
 
@@ -83,6 +85,16 @@ public class UserBE extends CommonBusinessEntity implements BusinessEntity {
 
     public void setUserPassword(final String userPassword) {
         this.userPassword = userPassword;
+    }
+
+
+    public Long getDsb_mitglied_id() {
+        return dsb_mitglied_id;
+    }
+
+
+    public void setDsb_mitglied_id(final Long dsb_mitglied_id) {
+        this.dsb_mitglied_id = dsb_mitglied_id;
     }
 
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/mapper/UserMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/mapper/UserMapper.java
@@ -40,7 +40,7 @@ public class UserMapper implements ValueObjectMapper {
         OffsetDateTime createdAtUtc = DateProvider.convertTimestamp(be.getCreatedAtUtc());
         OffsetDateTime lastModifiedAtUtc = DateProvider.convertTimestamp(be.getLastModifiedAtUtc());
 
-        return new UserDO(id, email, be.isUsing2FA(), be.isActive(), be.getSecret(), createdAtUtc, createdByUserId, lastModifiedAtUtc,
+        return new UserDO(id, email, be.getDsb_mitglied_id(), be.isUsing2FA(), be.isActive(), be.getSecret(), createdAtUtc, createdByUserId, lastModifiedAtUtc,
                 lastModifiedByUserId, version);
     };
 
@@ -65,6 +65,7 @@ public class UserMapper implements ValueObjectMapper {
         UserBE userBE = new UserBE();
         userBE.setUserId(vo.getId());
         userBE.setUserEmail(vo.getEmail());
+        userBE.setDsb_mitglied_id(vo.getDsb_mitglied_id());
         userBE.setUsing2FA(vo.isUsing2FA());
         userBE.setSecret(vo.getSecret());
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/user/impl/business/UserComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/user/impl/business/UserComponentImplTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings({"pmd-unit-tests:JUnitTestsShouldIncludeAssert", "squid:S2187"})
 public class UserComponentImplTest {
     private static final Long ID = 777L;
+    private static final Long DSBMITGLIEDID = 28L;
     private static final Long VERSION = 2L;
     private static final Long NEWVERSION = 3L;
     private static final String EMAIL = "email";
@@ -332,7 +333,7 @@ public class UserComponentImplTest {
     public void create_UserEmailnotNull() {
 
         assertThatExceptionOfType(BusinessException.class)
-                .isThrownBy(() -> underTest.create("", PASSWORD, ID, false))
+                .isThrownBy(() -> underTest.create("", PASSWORD, DSBMITGLIEDID, ID, false))
                 .withMessageContaining("must not be null")
                 .withNoCause();
 
@@ -343,7 +344,7 @@ public class UserComponentImplTest {
     public void create_UserPasswordnotNull() {
 
         assertThatExceptionOfType(BusinessException.class)
-                .isThrownBy(() -> underTest.create(EMAIL, "", ID, false))
+                .isThrownBy(() -> underTest.create(EMAIL, "", DSBMITGLIEDID, ID, false))
                 .withMessageContaining("must not be null")
                 .withNoCause();
 
@@ -354,7 +355,17 @@ public class UserComponentImplTest {
     public void create_UserIDnotNull() {
 
         assertThatExceptionOfType(BusinessException.class)
-                .isThrownBy(() -> underTest.create(EMAIL, PASSWORD, null, false))
+                .isThrownBy(() -> underTest.create(EMAIL, PASSWORD, DSBMITGLIEDID,null, false))
+                .withMessageContaining("must not be null")
+                .withNoCause();
+
+    }
+
+    @Test
+    public void create_DSBIDIDnotNull() {
+
+        assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> underTest.create(EMAIL, PASSWORD, null,ID, false))
                 .withMessageContaining("must not be null")
                 .withNoCause();
 
@@ -382,7 +393,7 @@ public class UserComponentImplTest {
         when(userDAO.create(any(UserBE.class), anyLong())).thenReturn(expectedBE);
 
         // call test method
-        final UserDO actual = underTest.create(EMAIL, PASSWORD, USER, false);
+        final UserDO actual = underTest.create(EMAIL, PASSWORD, DSBMITGLIEDID, USER, false);
 
         // assert result
         assertThat(actual).isNotNull();
@@ -429,6 +440,7 @@ public class UserComponentImplTest {
         final UserDO inUserDO = new UserDO();
         inUserDO.setId(ID);
         inUserDO.setEmail(EMAIL);
+        inUserDO.setDsb_mitglied_id(DSBMITGLIEDID);
 
 
         assertThatExceptionOfType(BusinessException.class)
@@ -445,6 +457,7 @@ public class UserComponentImplTest {
         final UserDO inUserDO = new UserDO();
         inUserDO.setId(ID);
         inUserDO.setEmail(EMAIL);
+        inUserDO.setDsb_mitglied_id(DSBMITGLIEDID);
 
 
         assertThatExceptionOfType(BusinessException.class)
@@ -461,6 +474,7 @@ public class UserComponentImplTest {
         final UserDO inUserDO = new UserDO();
         inUserDO.setId(ID);
         inUserDO.setEmail(EMAIL);
+        inUserDO.setDsb_mitglied_id(DSBMITGLIEDID);
 
 
         assertThatExceptionOfType(BusinessException.class)
@@ -502,6 +516,7 @@ public class UserComponentImplTest {
         final UserDO inUserDO = new UserDO();
         inUserDO.setId(ID);
         inUserDO.setEmail(EMAIL);
+        inUserDO.setDsb_mitglied_id(DSBMITGLIEDID);
 
 
         // configure mocks
@@ -548,6 +563,7 @@ public class UserComponentImplTest {
         final UserDO inUserDO = new UserDO();
         inUserDO.setId(ID);
         inUserDO.setEmail(EMAIL);
+        inUserDO.setDsb_mitglied_id(DSBMITGLIEDID);
 
 
         // configure mocks

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/user/impl/business/UserProfileComponentImplTest.java
@@ -64,8 +64,9 @@ public class UserProfileComponentImplTest {
 
     public static UserBE getUserBE() {
         UserBE userBE = new UserBE();
-        userBE.setUserId(ID);
+        userBE.setUserId(USERID);
         userBE.setUserEmail(EMAIL);
+        userBE.setDsb_mitglied_id(ID);
         return userBE;
     }
 
@@ -76,11 +77,11 @@ public class UserProfileComponentImplTest {
         final UserBE expectedUserBE = getUserBE();
 
         // configure mocks
-        when(dsbMitgliedDAO.findByUserId(ID)).thenReturn(expectedDsbMitgliedBE);
-        when(userDAO.findById(ID)).thenReturn(expectedUserBE);
+        when(dsbMitgliedDAO.findById(ID)).thenReturn(expectedDsbMitgliedBE);
+        when(userDAO.findById(USERID)).thenReturn(expectedUserBE);
 
         // call test method
-        final UserProfileDO actual = underTest.findById(ID);
+        final UserProfileDO actual = underTest.findById(USERID);
 
         // assert result
         assertThat(actual).isNotNull();


### PR DESCRIPTION
Erweiterung des Dialogs zum Neuanlage eines Benutzers um eine Auswahl bestehender DSB-Mitglieder (Pflichtfeld). Umbau der Tabelle Benutzer (neues Feld DSB-Mitglieds-ID) und Lösen der Fremdschlüssel-Beziehung von DBS-Mitglied auf Benutzer sowie neue Beziehung Benutzer auf DSB-Mitglied. Umbau des Benutzer-Profils-Lesens so dass alle Benutzer-Attribute gelesen werden. SQK-Skript zur Migration des bestehenden Daten (Lokal wird, wenn noch nicht vorhanden das DSB-Mitglied Gero Gras angelegt ;-)) global werden alle existierenden Benutzer dem DSB-Mitglied Gero zugeordnet.