### PR TITLE
 BSAPP-682: Abbilden des Vor- und Nachnamens eines Mannschaftsmitlgieds korrigiert

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/mapper/MannschaftsMitgliedDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/mapper/MannschaftsMitgliedDTOMapper.java
@@ -8,17 +8,18 @@ import de.bogenliga.application.services.v1.mannschaftsmitglied.model.Mannschaft
 public class MannschaftsMitgliedDTOMapper implements DataTransferObject {
     private static final long serialVersionUID = -6617029287670580334L;
 
+    private MannschaftsMitgliedDTOMapper() {
+    }
+
     public static final Function<MannschaftsmitgliedDO, MannschaftsMitgliedDTO> toDTO = mannschaftsMitgliedDO -> {
         final Long id = mannschaftsMitgliedDO.getId();
         final Long mannschaftId = mannschaftsMitgliedDO.getMannschaftId();
         final Long dsbMitgliedId = mannschaftsMitgliedDO.getDsbMitgliedId();
         final Integer dsbMitgliedEingesetzt = mannschaftsMitgliedDO.getDsbMitgliedEingesetzt();
-        final String dsbMitgliedVorname = mannschaftsMitgliedDO.getDsbMitgliedVorname();
-        final String dsbMitgliedNachname = mannschaftsMitgliedDO.getDsbMitgliedNachname();
         final Long rueckennummer = mannschaftsMitgliedDO.getRueckennummer();
 
         return new MannschaftsMitgliedDTO(id, mannschaftId,
-                dsbMitgliedId, dsbMitgliedEingesetzt, dsbMitgliedVorname, dsbMitgliedNachname, rueckennummer);
+                dsbMitgliedId, dsbMitgliedEingesetzt, rueckennummer);
     };
 
     public static final Function<MannschaftsMitgliedDTO, MannschaftsmitgliedDO> toDO = dto -> {
@@ -26,15 +27,10 @@ public class MannschaftsMitgliedDTOMapper implements DataTransferObject {
         final Long mannschaftId = dto.getMannschaftsId();
         final Long dsbMitgliedId = dto.getDsbMitgliedId();
         final Integer dsbMitgliedEingesetzt = dto.getDsbMitgliedEingesetzt();
-        final String dsbMitgliedVorname = dto.getDsbMitgliedVorname();
-        final String dsbMitgliedNachname = dto.getDsbMitgliedNachname();
         final Long rueckennummer = dto.getRueckennummer();
 
         return new MannschaftsmitgliedDO(id, mannschaftId,
-                dsbMitgliedId, dsbMitgliedEingesetzt, dsbMitgliedVorname, dsbMitgliedNachname, rueckennummer);
+                dsbMitgliedId, dsbMitgliedEingesetzt, "","", rueckennummer);
     };
 
-
-    private MannschaftsMitgliedDTOMapper() {
-    }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/model/MannschaftsMitgliedDTO.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/model/MannschaftsMitgliedDTO.java
@@ -9,8 +9,6 @@ public class MannschaftsMitgliedDTO implements DataTransferObject {
     private Long mannschaftsId;
     private Long dsbMitgliedId;
     private Integer dsbMitgliedEingesetzt;
-    private String dsbMitgliedVorname;
-    private String dsbMitgliedNachname;
     private Long rueckennummer;
 
 
@@ -20,14 +18,11 @@ public class MannschaftsMitgliedDTO implements DataTransferObject {
 
     public MannschaftsMitgliedDTO(final Long id, final Long mannschaftsId, final Long dsbMitgliedId,
                                   final Integer dsbMitgliedEingesetzt,
-                                  final String dsbMitgliedVorname, final String getDsbMitgliedNachname,
                                   final Long rueckennummer) {
         this.id = id;
         this.mannschaftsId = mannschaftsId;
         this.dsbMitgliedId = dsbMitgliedId;
         this.dsbMitgliedEingesetzt = dsbMitgliedEingesetzt;
-        this.dsbMitgliedVorname = dsbMitgliedVorname;
-        this.dsbMitgliedNachname = getDsbMitgliedNachname;
         this.rueckennummer = rueckennummer;
     }
 
@@ -61,31 +56,9 @@ public class MannschaftsMitgliedDTO implements DataTransferObject {
         this.dsbMitgliedEingesetzt = dsbMitgliedEingesetzt;
     }
 
-
-    public String getDsbMitgliedVorname() {
-        return dsbMitgliedVorname;
-    }
-
-
-    public void setDsbMitgliedVorname(String dsbMitgliedVorname) {
-        this.dsbMitgliedVorname = dsbMitgliedVorname;
-    }
-
-
-    public String getDsbMitgliedNachname() {
-        return dsbMitgliedNachname;
-    }
-
-
-    public void setDsbMitgliedNachname(String dsbMitgliedNachname) {
-        this.dsbMitgliedNachname = dsbMitgliedNachname;
-    }
-
-
     public Long getId() {
         return id;
     }
-
 
     public void setId(Long id) {
         this.id = id;

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
@@ -737,7 +737,13 @@ public class MatchService implements ServiceFacade {
 
 
     private boolean passeExists(PasseDO passeDO) {
-        return passeDO.getId() != null;
+        boolean exists = false;
+        if (passeDO.getId() != null) { // Is passeDO id already null
+            // If no, check if it actually exists in DB
+            PasseDO queriedPasseDO = passeComponent.findById(passeDO.getId());
+            exists = queriedPasseDO != null;
+        }
+        return exists;
     }
 
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -366,6 +366,9 @@ public class MatchServiceTest {
 
         PasseDTO passe1 = getPasseDTO(PASSE_ID_1, toIntExact(MM_rueckennummer_1));
         PasseDTO passe2 = getPasseDTO(PASSE_ID_2, toIntExact(MM_rueckennummer_2));
+        PasseDO passe1DO = PasseDTOMapper.toDO.apply(passe1);
+        PasseDO passe2DO = PasseDTOMapper.toDO.apply(passe2);
+
         // change lfdnr of passe2 to make them distinguishable
         passe2.setLfdNr(PASSE_LFDR_NR + 1);
 
@@ -380,6 +383,9 @@ public class MatchServiceTest {
         matches.add(matchDTO);
 
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
+        when(mannschaftsmitgliedComponent.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(getMannschaftsMitglieder().get(0));
+        when(passeComponent.findById(PASSE_ID_1)).thenReturn(passe1DO);
+        when(passeComponent.findById(PASSE_ID_2)).thenReturn(passe2DO);
 
         final List<MatchDTO> actual = underTest.saveMatches(matches, principal);
         assertThat(actual).isNotNull().isNotEmpty().hasSize(2);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImpl.java
@@ -8,6 +8,7 @@ import de.bogenliga.application.business.mannschaftsmitglied.api.Mannschaftsmitg
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.dao.MannschaftsmitgliedDAO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.mapper.MannschaftsmitgliedMapper;
 import de.bogenliga.application.common.errorhandling.ErrorCode;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
@@ -52,20 +53,17 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
         this.mannschaftsmitgliedDAO = mannschaftsmitgliedDAO;
     }
 
-
     @Override
     public List<MannschaftsmitgliedDO> findAll() {
-        final List<MannschaftsmitgliedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAll();
+        final List<MannschaftsmitgliedExtendedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAll();
         return mannschaftsmitgliedBEList.stream().map(MannschaftsmitgliedMapper.toMannschaftsmitgliedDO).collect(
                 Collectors.toList());
-
     }
-
 
     @Override
     public List<MannschaftsmitgliedDO> findAllSchuetzeInTeamEingesetzt(Long mannschaftsId) {
         checkPreconditions(mannschaftsId, PRECONDITION_FIELD_MANNSCHAFT_ID);
-        final List<MannschaftsmitgliedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAllSchuetzeInTeamEingesetzt(
+        final List<MannschaftsmitgliedExtendedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAllSchuetzeInTeamEingesetzt(
                 mannschaftsId);
         return mannschaftsmitgliedBEList.stream().map(MannschaftsmitgliedMapper.toMannschaftsmitgliedDO).collect(
                 Collectors.toList());
@@ -74,7 +72,7 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
     @Override
     public List<MannschaftsmitgliedDO> findAllSchuetzeInTeam(Long mannschaftsId) {
         checkPreconditions(mannschaftsId, PRECONDITION_FIELD_MANNSCHAFT_ID);
-        final List<MannschaftsmitgliedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAllSchuetzeInTeam(
+        final List<MannschaftsmitgliedExtendedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findAllSchuetzeInTeam(
                 mannschaftsId);
         return mannschaftsmitgliedBEList.stream().map(MannschaftsmitgliedMapper.toMannschaftsmitgliedDO).collect(
                 Collectors.toList());
@@ -83,12 +81,11 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
     @Override
     public List<MannschaftsmitgliedDO> findByTeamId(Long mannschaftsId) {
         checkPreconditions(mannschaftsId, PRECONDITION_FIELD_MANNSCHAFT_ID);
-        final List<MannschaftsmitgliedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findByTeamId(
+        final List<MannschaftsmitgliedExtendedBE> mannschaftsmitgliedBEList = mannschaftsmitgliedDAO.findByTeamId(
                 mannschaftsId);
         return mannschaftsmitgliedBEList.stream().map(MannschaftsmitgliedMapper.toMannschaftsmitgliedDO).collect(
                 Collectors.toList());
     }
-
 
     @Override
     public MannschaftsmitgliedDO findByMemberAndTeamId(Long mannschaftId, Long mitgliedId) {
@@ -97,7 +94,7 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
         Preconditions.checkArgument(mannschaftId >= 0, PRECONDITION_MANNSCHAFTSMITGLIED_MANNSCHAFT_ID_NEGATIV);
         Preconditions.checkArgument(mitgliedId >= 0, PRECONDITION_MANNSCHAFTSMITGLIED_MITGLIED_ID_NEGATIV);
 
-        final MannschaftsmitgliedBE result = mannschaftsmitgliedDAO.findByMemberAndTeamId(mannschaftId, mitgliedId);
+        final MannschaftsmitgliedExtendedBE result = mannschaftsmitgliedDAO.findByMemberAndTeamId(mannschaftId, mitgliedId);
 
         if (result == null) {
             throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND_ERROR,
@@ -113,7 +110,7 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
         checkPreconditions(mitgliedId, PRECONDITION_FIELD_MITGLIED_ID);
         Preconditions.checkArgument(mitgliedId >= 0, PRECONDITION_MANNSCHAFTSMITGLIED_MITGLIED_ID_NEGATIV);
 
-        final List<MannschaftsmitgliedBE> result = mannschaftsmitgliedDAO.findByMemberId(mitgliedId);
+        final List<MannschaftsmitgliedExtendedBE> result = mannschaftsmitgliedDAO.findByMemberId(mitgliedId);
 
         if (result == null) {
             throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND_ERROR,
@@ -135,9 +132,10 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
         final MannschaftsmitgliedBE persistedMannschaftsmitgliedBE = mannschaftsmitgliedDAO.create(
                 mannschaftsmitgliedBE, currentUserId);
 
-        return MannschaftsmitgliedMapper.toMannschaftsmitgliedDO.apply(persistedMannschaftsmitgliedBE);
+        return MannschaftsmitgliedMapper.toMannschaftsmitgliedDO.apply(
+                mannschaftsmitgliedDAO.findByMemberAndTeamId(persistedMannschaftsmitgliedBE.getMannschaftId(),
+                                                                persistedMannschaftsmitgliedBE.getDsbMitgliedId()));
     }
-
 
     @Override
     public MannschaftsmitgliedDO update(MannschaftsmitgliedDO mannschaftsmitgliedDO,
@@ -153,12 +151,14 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
 
         final MannschaftsmitgliedBE mannschaftsmitgliedBE = MannschaftsmitgliedMapper.toMannschaftsmitgliedBE.apply(
                 mannschaftsmitgliedDO);
-        final MannschaftsmitgliedBE persistedMannschaftsmitgliederBE = mannschaftsmitgliedDAO.update(
+        final MannschaftsmitgliedBE persistedMannschaftsmitgliedBE = mannschaftsmitgliedDAO.update(
                 mannschaftsmitgliedBE, currentUserId);
+        final MannschaftsmitgliedExtendedBE resultMannschaftsmitgliedBE =
+                mannschaftsmitgliedDAO.findByMemberAndTeamId(persistedMannschaftsmitgliedBE.getMannschaftId(),
+                        persistedMannschaftsmitgliedBE.getDsbMitgliedId());
 
-        return MannschaftsmitgliedMapper.toMannschaftsmitgliedDO.apply(persistedMannschaftsmitgliederBE);
+        return MannschaftsmitgliedMapper.toMannschaftsmitgliedDO.apply(resultMannschaftsmitgliedBE);
     }
-
 
     @Override
     public void deleteByTeamIdAndMemberId(MannschaftsmitgliedDO mannschaftsmitgliedDO, final Long currentUserId) {
@@ -189,7 +189,6 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
         mannschaftsmitgliedDAO.delete(mannschaftsmitgliedBE,currentUserId);
     }
 
-
     @Override
     public boolean checkExistingSchuetze(Long mannschaftId, final Long mitgliedId) {
         Preconditions.checkArgument(mannschaftId >= 0, PRECONDITION_MANNSCHAFTSMITGLIED_MANNSCHAFT_ID_NEGATIV);
@@ -199,7 +198,6 @@ public class MannschaftsmitgliedComponentImpl implements MannschaftsmitgliedComp
 
         return result.getDsbMitgliedEingesetzt() > 0;
     }
-
 
     private void checkMannschaftsmitgliedDO(final MannschaftsmitgliedDO mannschaftsmitgliedDO) {
         Preconditions.checkNotNull(mannschaftsmitgliedDO, PRECONDITION_MANNSCHAFTSMITGLIED);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
@@ -216,7 +216,7 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
     public MannschaftsmitgliedBE update(final MannschaftsmitgliedBE mannschaftsmitgliedBE, final long currentMemberId) {
         basicDao.setModificationAttributes(mannschaftsmitgliedBE, currentMemberId);
 
-        return basicDao.updateEntity(MANNSCHAFTSMITGLIED, mannschaftsmitgliedBE, MANNSCHAFTSMITGLIED_BE_DSB_MITGLIED_ID);
+        return basicDao.updateEntity(MANNSCHAFTSMITGLIED, mannschaftsmitgliedBE, MANNSCHAFTSMITGLIED_BE_ID);
     }
 
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.component.dao.BasicDAO;
 import de.bogenliga.application.common.component.dao.BusinessEntityConfiguration;
 import de.bogenliga.application.common.component.dao.DataAccessObject;
@@ -94,12 +95,6 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
             .whereEquals(MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID)
             .compose().toString();
 
-    private static final String FIND_BY_DSBMITGLIED_ID = new QueryBuilder()
-            .selectAll()
-            .from(TABLE)
-            .whereEquals(MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID)
-            .compose().toString();
-
     //hier suchen wir  alle Teammtiglieder, die eingesetzt wurden
     // d.h. nicht nur gemeldet, sondern sie haben auch Pfeilwerte erfasst
     private static final String FIND_ALL_SCHUETZE_TEAM_EINGESETZT = new QueryBuilder()
@@ -125,13 +120,13 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
             .orderBy(MANNSCHAFTSMITGLIED_TABLE_ID)
             .compose().toString();
 
-    // wrap all specific config parameters
-    private static final BusinessEntityConfiguration<MannschaftsmitgliedBE> MANNSCHAFTSMITGLIED_JOINED = new BusinessEntityConfiguration<>(
-            MannschaftsmitgliedBE.class, TABLE, getColumnsToFieldsMap(true), LOGGER);
 
     // wrap all specific config parameters
     private static final BusinessEntityConfiguration<MannschaftsmitgliedBE> MANNSCHAFTSMITGLIED = new BusinessEntityConfiguration<>(
-            MannschaftsmitgliedBE.class, TABLE, getColumnsToFieldsMap(false), LOGGER);
+            MannschaftsmitgliedBE.class, TABLE, getColumnsToFieldsMap(), LOGGER);
+
+    private static final BusinessEntityConfiguration<MannschaftsmitgliedExtendedBE> MANNSCHAFTSMITGLIED_EXTENDED = new BusinessEntityConfiguration<>(
+            MannschaftsmitgliedExtendedBE.class, TABLE, getColumnsToFieldsMapExtended(), LOGGER);
 
 
     private final BasicDAO basicDao;
@@ -144,7 +139,7 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
 
 
     // table column label mapping to the business entity parameter names
-    private static Map<String, String> getColumnsToFieldsMap(boolean joined) {
+    private static Map<String, String> getColumnsToFieldsMap() {
         final Map<String, String> columnsToFieldsMap = new HashMap<>();
 
         columnsToFieldsMap.put(MANNSCHAFTSMITGLIED_TABLE_ID, MANNSCHAFTSMITGLIED_BE_ID);
@@ -153,26 +148,33 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
         columnsToFieldsMap.put(MANNSCHAFTSMITGLIED_TABLE_EMPLOYED, MANNSCHAFTSMITGLIED_BE_INSERT);
         columnsToFieldsMap.put(MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER, MANNSCHAFTSMITGLIED_BE_RUECKENNUMMER);
 
-        // Only add DSBMitglied Columns when query using this method specifies it will result in a joined table
-        if (joined) {
-            // new: important for the join with dsb_mitglied
-            columnsToFieldsMap.put(DSBMITGLIED_TABLE_FORENAME, DSBMITGLIED_BE_FORENAME);
-            columnsToFieldsMap.put(DSBMITGLIED_TABLE_SURNAME, DSBMITGLIED_BE_SURNAME);
-        }
-
         // add technical columns
         columnsToFieldsMap.putAll(BasicDAO.getTechnicalColumnsToFieldsMap());
         return columnsToFieldsMap;
     }
 
+    private static Map<String, String> getColumnsToFieldsMapExtended() {
+        final Map<String, String> columnsToFieldsMapExtended = new HashMap<>();
+
+        columnsToFieldsMapExtended.put(MANNSCHAFTSMITGLIED_TABLE_ID, MANNSCHAFTSMITGLIED_BE_ID);
+        columnsToFieldsMapExtended.put(MANNSCHAFTSMITGLIED_TABLE_TEAM_ID, MANNSCHAFTSMITGLIED_BE_TEAM_ID);
+        columnsToFieldsMapExtended.put(MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID, MANNSCHAFTSMITGLIED_BE_DSB_MITGLIED_ID);
+        columnsToFieldsMapExtended.put(MANNSCHAFTSMITGLIED_TABLE_EMPLOYED, MANNSCHAFTSMITGLIED_BE_INSERT);
+        columnsToFieldsMapExtended.put(MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER, MANNSCHAFTSMITGLIED_BE_RUECKENNUMMER);
+        columnsToFieldsMapExtended.put(DSBMITGLIED_TABLE_FORENAME, DSBMITGLIED_BE_FORENAME);
+        columnsToFieldsMapExtended.put(DSBMITGLIED_TABLE_SURNAME, DSBMITGLIED_BE_SURNAME);
+
+        // add technical columns
+        columnsToFieldsMapExtended.putAll(BasicDAO.getTechnicalColumnsToFieldsMap());
+        return columnsToFieldsMapExtended;
+    }
 
     /**
      * Return all mannschaftsmitglied entries
      */
-    public List<MannschaftsmitgliedBE> findAll() {
-        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_JOINED, FIND_ALL);
+    public List<MannschaftsmitgliedExtendedBE> findAll() {
+        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_EXTENDED, FIND_ALL);
     }
-
 
     /**
      * return all members in the team
@@ -181,28 +183,26 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
      *
      * @return
      */
-    public List<MannschaftsmitgliedBE> findByTeamId(final long id) {
-        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_JOINED, FIND_BY_TEAM_ID, id);
+    public List<MannschaftsmitgliedExtendedBE> findByTeamId(final long id) {
+        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_EXTENDED, FIND_BY_TEAM_ID, id);
     }
 
 
-    public List<MannschaftsmitgliedBE> findAllSchuetzeInTeamEingesetzt(final long id) {
-        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_JOINED, FIND_ALL_SCHUETZE_TEAM_EINGESETZT, id);
+    public List<MannschaftsmitgliedExtendedBE> findAllSchuetzeInTeamEingesetzt(final long id) {
+        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_EXTENDED, FIND_ALL_SCHUETZE_TEAM_EINGESETZT, id);
     }
 
-    public List<MannschaftsmitgliedBE> findAllSchuetzeInTeam(final long id) {
-        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_JOINED, FIND_ALL_SCHUETZE_TEAM, id);
+    public List<MannschaftsmitgliedExtendedBE> findAllSchuetzeInTeam(final long id) {
+        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_EXTENDED, FIND_ALL_SCHUETZE_TEAM, id);
     }
 
 
-    public MannschaftsmitgliedBE findByMemberAndTeamId(long teamId, final long memberId) {
-        MannschaftsmitgliedBE test;
-        test = basicDao.selectSingleEntity(MANNSCHAFTSMITGLIED_JOINED, FIND_BY_MEMBER_AND_TEAM_ID, memberId, teamId);
-        return test;
+    public MannschaftsmitgliedExtendedBE findByMemberAndTeamId(long teamId, final long memberId) {
+       return basicDao.selectSingleEntity(MANNSCHAFTSMITGLIED_EXTENDED, FIND_BY_MEMBER_AND_TEAM_ID, memberId, teamId);
     }
 
-    public List<MannschaftsmitgliedBE> findByMemberId(final long memberId) {
-        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_JOINED, FIND_BY_DSBMITGLIED_ID, memberId);
+    public List<MannschaftsmitgliedExtendedBE> findByMemberId(final long memberId) {
+        return basicDao.selectEntityList(MANNSCHAFTSMITGLIED_EXTENDED, FIND_BY_MEMBER_ID, memberId);
     }
 
 
@@ -222,7 +222,6 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
 
     public void delete(final MannschaftsmitgliedBE mannschaftsmitgliedBE, final long currentMemberId) {
         basicDao.setModificationAttributes(mannschaftsmitgliedBE, currentMemberId);
-
         basicDao.deleteEntity(MANNSCHAFTSMITGLIED, mannschaftsmitgliedBE, MANNSCHAFTSMITGLIED_BE_ID);
     }
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedBE.java
@@ -7,13 +7,11 @@ import de.bogenliga.application.common.component.entity.CommonBusinessEntity;
 public class MannschaftsmitgliedBE extends CommonBusinessEntity implements BusinessEntity {
     private static final long serialVersionUID = 2616130134662239870L;
 
-    private Long id;
-    private Long mannschaftId;
-    private Long dsbMitgliedId;
-    private Integer dsbMitgliedEingesetzt;
-    private String dsbMitgliedVorname;
-    private String dsbMitgliedNachname;
-    private Long rueckennummer;
+    protected Long id;
+    protected Long mannschaftId;
+    protected Long dsbMitgliedId;
+    protected Integer dsbMitgliedEingesetzt;
+    protected Long rueckennummer;
 
 
     /**
@@ -52,26 +50,9 @@ public class MannschaftsmitgliedBE extends CommonBusinessEntity implements Busin
         this.dsbMitgliedEingesetzt = dsbMitgliedEingesetzt;
     }
 
-
-    public String getDsbMitgliedVorname() {
-        return dsbMitgliedVorname;
-    }
-
-
-    public void setDsbMitgliedVorname(final String dsbMitgliedVorname) {
-        this.dsbMitgliedVorname = dsbMitgliedVorname;
-    }
-
-
-    public String getDsbMitgliedNachname() {
-        return dsbMitgliedNachname;
-    }
-
-
     public Long getId() {
         return id;
     }
-
 
     public void setId(Long id) {
         this.id = id;
@@ -81,12 +62,6 @@ public class MannschaftsmitgliedBE extends CommonBusinessEntity implements Busin
 
     public void setRueckennummer(Long rueckennummer) { this.rueckennummer = rueckennummer; }
 
-
-    public void setDsbMitgliedNachname(final String dsbMitgliedNachname) {
-        this.dsbMitgliedNachname = dsbMitgliedNachname;
-    }
-
-
     @Override
     public String toString() {
         return "MannschaftsmitgliedBE{" +
@@ -94,8 +69,6 @@ public class MannschaftsmitgliedBE extends CommonBusinessEntity implements Busin
                 "mannschaftId=" + mannschaftId +
                 ", dsbMitgliedId=" + dsbMitgliedId +
                 ", dsbMitgliedEingesetzt=" + dsbMitgliedEingesetzt +
-                ", dsbMitgliedVorname=" + dsbMitgliedVorname +
-                ", dsbMitgliedNachname=" + dsbMitgliedNachname +
                 ", rueckennummer=" + rueckennummer +
                 '}';
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedExtendedBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedExtendedBE.java
@@ -1,0 +1,105 @@
+package de.bogenliga.application.business.mannschaftsmitglied.impl.entity;
+
+/**
+ * extends ManschaftsmitgliedBE by fore- and surname from dsb-Mitglied
+ */
+public class MannschaftsmitgliedExtendedBE extends MannschaftsmitgliedBE {
+
+    private String dsbMitgliedVorname;
+    private String dsbMitgliedNachname;
+
+    public MannschaftsmitgliedExtendedBE() {
+    }
+
+    // IMPORTANT
+    // Methods from Base class need to be overwritten because of the BasicTest-class
+    // the BasicTest-class does not recognize that there are inherited methods
+    // this results into failure within running the unit-tests
+    @Override
+    public Long getId() {
+        return super.getId();
+    }
+
+    @Override
+    public Long getMannschaftId() {
+        return super.getMannschaftId();
+    }
+
+
+    @Override
+    public void setMannschaftId(Long mannschaftId) {
+        super.setMannschaftId(mannschaftId);
+    }
+
+
+    @Override
+    public Long getDsbMitgliedId() {
+        return super.getDsbMitgliedId();
+    }
+
+
+    @Override
+    public void setDsbMitgliedId(Long dsbMitgliedId) {
+        super.setDsbMitgliedId(dsbMitgliedId);
+    }
+
+
+    @Override
+    public Integer getDsbMitgliedEingesetzt() {
+        return super.getDsbMitgliedEingesetzt();
+    }
+
+
+    @Override
+    public void setDsbMitgliedEingesetzt(Integer dsbMitgliedEingesetzt) {
+        super.setDsbMitgliedEingesetzt(dsbMitgliedEingesetzt);
+    }
+
+
+    @Override
+    public void setId(Long id) {
+        super.setId(id);
+    }
+
+
+    @Override
+    public Long getRueckennummer() {
+        return super.getRueckennummer();
+    }
+
+
+    @Override
+    public void setRueckennummer(Long rueckennummer) {
+        super.setRueckennummer(rueckennummer);
+    }
+
+
+    public String getDsbMitgliedVorname() {
+        return dsbMitgliedVorname;
+    }
+
+    public void setDsbMitgliedVorname(String dsbMitgliedVorname) {
+        this.dsbMitgliedVorname = dsbMitgliedVorname;
+    }
+
+    public String getDsbMitgliedNachname() {
+        return dsbMitgliedNachname;
+    }
+
+    public void setDsbMitgliedNachname(String dsbMitgliedNachname) {
+        this.dsbMitgliedNachname = dsbMitgliedNachname;
+    }
+
+    @Override
+    public String toString() {
+        return "MannschaftsmitgliedExtendedBE{" +
+                "id=" + id +
+                "mannschaftId=" + mannschaftId +
+                ", dsbMitgliedId=" + dsbMitgliedId +
+                ", dsbMitgliedEingesetzt=" + dsbMitgliedEingesetzt +
+                ", dsbMitgliedVorname=" + dsbMitgliedVorname +
+                ", dsbMitgliedNachname=" + dsbMitgliedNachname +
+                ", rueckennummer=" + rueckennummer +
+                '}';
+    }
+}

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/mapper/MannschaftsmitgliedMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/mapper/MannschaftsmitgliedMapper.java
@@ -5,31 +5,36 @@ import java.time.OffsetDateTime;
 import java.util.function.Function;
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.component.mapping.ValueObjectMapper;
 import de.bogenliga.application.common.time.DateProvider;
 
+
 /**
- * @author Philip Dengler
+ * @author Philip Dengler; Edited by: Jonas Müller, Felix Maute
+ * To ensure that MannschaftsmitgliedDOs that get passed down to the Data-Access-Layer don't have attributes which do not exist
+ * in the database table, but MannschaftsmitgliedDOs that get passed up to the Business-Layer can still have these attributes,
+ * we separated the DO into MannschaftsmitgliedBE and MannschaftsmitgliedExtendedBE which are mapped to the DO here.
  */
 public class MannschaftsmitgliedMapper implements ValueObjectMapper {
 
+    public static final Function<MannschaftsmitgliedExtendedBE, MannschaftsmitgliedDO> toMannschaftsmitgliedDO = beExtended -> {
+        final Long id = beExtended.getId();
+        final Long mannschaftId = beExtended.getMannschaftId();
+        final Long mitgliedId = beExtended.getDsbMitgliedId();
+        final Integer mitgliedEingesetzt = beExtended.getDsbMitgliedEingesetzt();
 
-    public static final Function<MannschaftsmitgliedBE, MannschaftsmitgliedDO> toMannschaftsmitgliedDO = be -> {
-        final Long id = be.getId();
-        final Long mannschaftId = be.getMannschaftId();
-        final Long mitgliedId = be.getDsbMitgliedId();
-        final Integer mitgliedEingesetzt = be.getDsbMitgliedEingesetzt();
-        final String mitgliedVorname = be.getDsbMitgliedVorname();
-        final String mitgliedNachname = be.getDsbMitgliedNachname();
-        final Long rueckennummer = be.getRueckennummer();
+        final String mitgliedVorname = beExtended.getDsbMitgliedVorname();
+        final String mitgliedNachname = beExtended.getDsbMitgliedNachname();
+        final Long rueckennummer = beExtended.getRueckennummer();
 
         // technical parameter
-        Long createdByUserId = be.getCreatedByUserId();
-        Long lastModifiedByUserId = be.getLastModifiedByUserId();
-        Long version = be.getVersion();
+        Long createdByUserId = beExtended.getCreatedByUserId();
+        Long lastModifiedByUserId = beExtended.getLastModifiedByUserId();
+        Long version = beExtended.getVersion();
 
-        OffsetDateTime createdAtUtc = DateProvider.convertTimestamp(be.getCreatedAtUtc());
-        OffsetDateTime lastModifiedAtUtc = DateProvider.convertTimestamp(be.getLastModifiedAtUtc());
+        OffsetDateTime createdAtUtc = DateProvider.convertTimestamp(beExtended.getCreatedAtUtc());
+        OffsetDateTime lastModifiedAtUtc = DateProvider.convertTimestamp(beExtended.getLastModifiedAtUtc());
 
         return new MannschaftsmitgliedDO(id, mannschaftId, mitgliedId, mitgliedEingesetzt, mitgliedVorname,
                 mitgliedNachname,  createdAtUtc, createdByUserId, lastModifiedAtUtc, lastModifiedByUserId, version, rueckennummer);
@@ -48,8 +53,6 @@ public class MannschaftsmitgliedMapper implements ValueObjectMapper {
         mannschaftsmitgliedBE.setMannschaftId(mannschaftsmitgliedDO.getMannschaftId());
         mannschaftsmitgliedBE.setDsbMitgliedId(mannschaftsmitgliedDO.getDsbMitgliedId());
         mannschaftsmitgliedBE.setDsbMitgliedEingesetzt(mannschaftsmitgliedDO.getDsbMitgliedEingesetzt());
-        mannschaftsmitgliedBE.setDsbMitgliedVorname(mannschaftsmitgliedDO.getDsbMitgliedVorname());
-        mannschaftsmitgliedBE.setDsbMitgliedNachname(mannschaftsmitgliedDO.getDsbMitgliedNachname());
 
         mannschaftsmitgliedBE.setCreatedAtUtc(createdAtUtcTimestamp);
         mannschaftsmitgliedBE.setCreatedByUserId(mannschaftsmitgliedDO.getCreatedByUserId());

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/MannschaftsmitgliedBaseDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/MannschaftsmitgliedBaseDAOTest.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 
 /**
  * TODO [AL] class documentation
@@ -43,8 +44,8 @@ public class MannschaftsmitgliedBaseDAOTest {
      * Also used by other test classes.
      */
 
-    public static MannschaftsmitgliedBE getMannschaftsmitgliedBE() {
-        final MannschaftsmitgliedBE expectedMannschaftsmitgliedBE = new MannschaftsmitgliedBE();
+    public static MannschaftsmitgliedExtendedBE getMannschaftsmitgliedExtendedBE() {
+        final MannschaftsmitgliedExtendedBE expectedMannschaftsmitgliedBE = new MannschaftsmitgliedExtendedBE();
         expectedMannschaftsmitgliedBE.setId(id);
         expectedMannschaftsmitgliedBE.setMannschaftId(mannschaftId);
         expectedMannschaftsmitgliedBE.setDsbMitgliedId(dsbMitgliedId);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.dao.MannschaftsmitgliedDAO;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -54,8 +55,8 @@ public class MannschaftsmitgliedComponentImplTest {
      * Utility methods for creating business entities/data objects.
      * Also used by other test classes.
      */
-    public static MannschaftsmitgliedBE getMannschatfsmitgliedBE() {
-        final MannschaftsmitgliedBE expectedBE = new MannschaftsmitgliedBE();
+    public static MannschaftsmitgliedExtendedBE getMannschatfsmitgliedExtendedBE() {
+        final MannschaftsmitgliedExtendedBE expectedBE = new MannschaftsmitgliedExtendedBE();
         expectedBE.setMannschaftId(MANNSCHAFTSID);
         expectedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
         expectedBE.setDsbMitgliedEingesetzt(DSB_MITGLIED_EINGESETZT);
@@ -80,8 +81,8 @@ public class MannschaftsmitgliedComponentImplTest {
     @Test
     public void findAll() {
         // prepare test data
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
-        final List<MannschaftsmitgliedBE> expectedBEList = Collections.singletonList(expectedBE);
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
+        final List<MannschaftsmitgliedExtendedBE> expectedBEList = Collections.singletonList(expectedBE);
 
         // configure mocks
         when(mannschaftsmitgliedDAO.findAll()).thenReturn(expectedBEList);
@@ -109,8 +110,8 @@ public class MannschaftsmitgliedComponentImplTest {
     @Test
     public void findAllSchuetzeInTeam() {
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
-        final List<MannschaftsmitgliedBE> expectedBEList = Collections.singletonList(expectedBE);
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
+        final List<MannschaftsmitgliedExtendedBE> expectedBEList = Collections.singletonList(expectedBE);
 
         // configure mocks
         when(mannschaftsmitgliedDAO.findAllSchuetzeInTeamEingesetzt(MANNSCHAFTSID)).thenReturn(expectedBEList);
@@ -134,7 +135,7 @@ public class MannschaftsmitgliedComponentImplTest {
     @Test
     public void findByMemberAndTeamId() {
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
 
 
         // configure mocks
@@ -150,8 +151,8 @@ public class MannschaftsmitgliedComponentImplTest {
 
     @Test
     public void findByTeamId() {
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
-        final List<MannschaftsmitgliedBE> expectedBEList = Collections.singletonList(expectedBE);
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
+        final List<MannschaftsmitgliedExtendedBE> expectedBEList = Collections.singletonList(expectedBE);
 
         // configure mocks
         when(mannschaftsmitgliedDAO.findByTeamId(MANNSCHAFTSID)).thenReturn(expectedBEList);
@@ -169,7 +170,7 @@ public class MannschaftsmitgliedComponentImplTest {
     @Test
     public void checkExistingSchuetze() {
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
         // configure mocks
         when(mannschaftsmitgliedDAO.findByMemberAndTeamId(MANNSCHAFTSID, DSB_MITGLIED_ID)).thenReturn(expectedBE);
         final boolean actual = underTest.checkExistingSchuetze(MANNSCHAFTSID, DSB_MITGLIED_ID);
@@ -182,10 +183,12 @@ public class MannschaftsmitgliedComponentImplTest {
 
         final MannschaftsmitgliedDO input = getMannschatfsmitgliedDO();
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedExtendedBE();
+        final MannschaftsmitgliedExtendedBE expectedExtendedBE = getMannschatfsmitgliedExtendedBE();
 
         // configure mocks
         when(mannschaftsmitgliedDAO.create(any(MannschaftsmitgliedBE.class), anyLong())).thenReturn(expectedBE);
+        when(mannschaftsmitgliedDAO.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(expectedExtendedBE);
 
         // call test method
         final MannschaftsmitgliedDO actual = underTest.create(input, USER);
@@ -226,8 +229,14 @@ public class MannschaftsmitgliedComponentImplTest {
         expectedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
         expectedBE.setDsbMitgliedEingesetzt(DSB_MITGLIED_EINGESETZT);
 
+        final MannschaftsmitgliedExtendedBE expectedExtendedBE = getMannschatfsmitgliedExtendedBE();
+        expectedExtendedBE.setMannschaftId(MANNSCHAFTSID);
+        expectedExtendedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
+        expectedExtendedBE.setDsbMitgliedEingesetzt(DSB_MITGLIED_EINGESETZT);
 
+        // configure mocks
         when(mannschaftsmitgliedDAO.create(any(MannschaftsmitgliedBE.class), anyLong())).thenReturn(expectedBE);
+        when(mannschaftsmitgliedDAO.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(expectedExtendedBE);
 
         // call test method
         final MannschaftsmitgliedDO actual = underTest.create(input, USER);
@@ -268,10 +277,12 @@ public class MannschaftsmitgliedComponentImplTest {
 
         final MannschaftsmitgliedDO input = getMannschatfsmitgliedDO();
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedExtendedBE();
+        final MannschaftsmitgliedExtendedBE expectedExtendedBE = getMannschatfsmitgliedExtendedBE();
 
         // configure mocks
         when(mannschaftsmitgliedDAO.update(any(MannschaftsmitgliedBE.class), anyLong())).thenReturn(expectedBE);
+        when(mannschaftsmitgliedDAO.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(expectedExtendedBE);
 
         // call test method
         final MannschaftsmitgliedDO actual = underTest.update(input, USER);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTestAll.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTestAll.java
@@ -15,6 +15,7 @@ import de.bogenliga.application.business.mannschaftsmitglied.impl.dao.Mannschaft
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
 import de.bogenliga.application.business.baseClass.impl.BasicComponentTest;
 import de.bogenliga.application.business.baseClass.impl.BasicTest;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.component.dao.BasicDAO;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -36,20 +37,25 @@ public class MannschaftsmitgliedComponentImplTestAll extends Mannschaftsmitglied
     private MannschaftsmitgliedDAO mannschaftsmitgliedDAO;
 
     private MannschaftsmitgliedBE expectedBE;
+    private MannschaftsmitgliedExtendedBE expectedExtendedBE;
 
     private MannschaftsmitgliedComponentImpl underTest;
 
 
     private BasicComponentTest<MannschaftsmitgliedComponentImpl, MannschaftsmitgliedDO> basicComponentTest;
     private BasicTest<MannschaftsmitgliedBE, MannschaftsmitgliedDO> basicTest;
+    private BasicTest<MannschaftsmitgliedExtendedBE, MannschaftsmitgliedDO> basicExtendedTest;
 
 
     @Before
     public void testSetup() {
-        expectedBE = getMannschaftsmitgliedBE();
+        expectedBE = getMannschaftsmitgliedExtendedBE();
+        expectedExtendedBE = getMannschaftsmitgliedExtendedBE();
         underTest = new MannschaftsmitgliedComponentImpl(mannschaftsmitgliedDAO);
         basicComponentTest = new BasicComponentTest<>(underTest);
         basicTest = new BasicTest<>(expectedBE, getValuesToMethodMap());
+        basicExtendedTest = new BasicTest<>(expectedExtendedBE, getValuesToMethodMap());
+
     }
 
 
@@ -65,27 +71,29 @@ public class MannschaftsmitgliedComponentImplTestAll extends Mannschaftsmitglied
 
     @Test
     public void testAllMethodsOnCorrectness() throws InvocationTargetException, IllegalAccessException {
-        when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
-        when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedBE);
-        basicTest.testAllFindMethods(underTest);
+        when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedExtendedBE));
+        when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedExtendedBE);
+        basicExtendedTest.testAllFindMethods(underTest);
     }
 
 
     @Test
     public void testCreateOnCorrectness() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         when(basicDAO.insertEntity(any(), any())).thenReturn(expectedBE);
+        when(basicDAO.selectSingleEntity(any(),any(),any(),any())).thenReturn(expectedBE);
         MannschaftsmitgliedDO p = basicComponentTest.testCreateMethod(getMannschaftsmitgliedDO());
         BasicTest b = new BasicTest<MannschaftsmitgliedDO, MannschaftsmitgliedBE>(p, getValuesToMethodMap());
-        b.assertEntity(getMannschaftsmitgliedBE());
+        b.assertEntity(getMannschaftsmitgliedExtendedBE());
     }
 
 
     @Test
     public void testUpdateOnCorrectness() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         when(basicDAO.updateEntity(any(), any(), any())).thenReturn(expectedBE);
+        when(basicDAO.selectSingleEntity(any(),any(),any(),any())).thenReturn(expectedBE);
         MannschaftsmitgliedDO p = basicComponentTest.testUpdateMethod(getMannschaftsmitgliedDO());
         BasicTest b = new BasicTest<MannschaftsmitgliedDO, MannschaftsmitgliedBE>(p, getValuesToMethodMap());
-        b.assertEntity(getMannschaftsmitgliedBE());
+        b.assertEntity(getMannschaftsmitgliedExtendedBE());
     }
 
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftmitgliedDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftmitgliedDAOTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.MannschaftsmitgliedBaseDAOTest;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
 import de.bogenliga.application.business.baseClass.impl.BasicTest;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.component.dao.BasicDAO;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -32,15 +33,15 @@ public class MannschaftmitgliedDAOTest extends MannschaftsmitgliedBaseDAOTest {
     @InjectMocks
     private MannschaftsmitgliedDAO underTest;
 
-    private MannschaftsmitgliedBE expectedBE;
+    private MannschaftsmitgliedExtendedBE expectedBE;
 
     // Implements generic way to test business entities methods
-    private BasicTest<MannschaftsmitgliedBE, MannschaftsmitgliedBE> basicDAOTest;
+    private BasicTest<MannschaftsmitgliedExtendedBE, MannschaftsmitgliedExtendedBE> basicDAOTest;
 
 
     @Before
     public void testSetup() {
-        expectedBE = getMannschaftsmitgliedBE();
+        expectedBE = getMannschaftsmitgliedExtendedBE();
         basicDAOTest = new BasicTest<>(expectedBE, getValuesToMethodMap());
 
         // configure mocks

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedBasicDAOTest.java
@@ -10,8 +10,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
+import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedExtendedBE;
 import de.bogenliga.application.common.component.dao.BasicDAO;
-import static de.bogenliga.application.business.mannschaftsmitglied.impl.business.MannschaftsmitgliedComponentImplTest.getMannschatfsmitgliedBE;
+import static de.bogenliga.application.business.mannschaftsmitglied.impl.business.MannschaftsmitgliedComponentImplTest.getMannschatfsmitgliedExtendedBE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,11 +39,11 @@ public class MannschaftsmitgliedBasicDAOTest {
 
     @Test
     public void findAll() {
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
 
         when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
-        final List<MannschaftsmitgliedBE> actual = underTest.findAll();
+        final List<MannschaftsmitgliedExtendedBE> actual = underTest.findAll();
 
         // assert result
         assertThat(actual)
@@ -64,7 +65,7 @@ public class MannschaftsmitgliedBasicDAOTest {
 
     @Test
     public void findByMemberAndTeamId() {
-        final MannschaftsmitgliedBE expectedBE = new MannschaftsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = new MannschaftsmitgliedExtendedBE();
         expectedBE.setMannschaftId(MANNSCHHAFT_ID);
         expectedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
         expectedBE.setDsbMitgliedEingesetzt(1);
@@ -92,7 +93,7 @@ public class MannschaftsmitgliedBasicDAOTest {
     @Test
     public void findByTeamId() {
         // prepare test data
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
 
         expectedBE.setMannschaftId(MANNSCHHAFT_ID);
         expectedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
@@ -102,7 +103,7 @@ public class MannschaftsmitgliedBasicDAOTest {
         when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
         // call test method
-        final List<MannschaftsmitgliedBE> actual = underTest.findByTeamId(MANNSCHHAFT_ID);
+        final List<MannschaftsmitgliedExtendedBE> actual = underTest.findByTeamId(MANNSCHHAFT_ID);
 
         // assert result
         assertThat(actual)
@@ -117,7 +118,7 @@ public class MannschaftsmitgliedBasicDAOTest {
     @Test
     public void checkExistingSchuetze() {
         // prepare test data
-        final MannschaftsmitgliedBE expectedBE = new MannschaftsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = new MannschaftsmitgliedExtendedBE();
         expectedBE.setMannschaftId(MANNSCHHAFT_ID);
         expectedBE.setDsbMitgliedId(DSB_MITGLIED_ID);
         expectedBE.setDsbMitgliedEingesetzt(1);
@@ -135,13 +136,13 @@ public class MannschaftsmitgliedBasicDAOTest {
     @Test
     public void findAllSchuetzeInTeam() {
 
-        final MannschaftsmitgliedBE expectedBE = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE expectedBE = getMannschatfsmitgliedExtendedBE();
 
         // configure mocks
         when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
         // call test method
-        final List<MannschaftsmitgliedBE> actual = underTest.findAllSchuetzeInTeamEingesetzt(MANNSCHHAFT_ID);
+        final List<MannschaftsmitgliedExtendedBE> actual = underTest.findAllSchuetzeInTeamEingesetzt(MANNSCHHAFT_ID);
         // assert result
         Java6Assertions.assertThat(actual)
                 .isNotNull()

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedBasicDAOTestAll.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedBasicDAOTestAll.java
@@ -39,7 +39,7 @@ public class MannschaftsmitgliedBasicDAOTestAll extends MannschaftsmitgliedBaseD
 
     @Before
     public void testSetup() {
-        expectedBE = getMannschaftsmitgliedBE();
+        expectedBE = getMannschaftsmitgliedExtendedBE();
         basicDAOTest = new BasicTest<>(expectedBE,getValuesToMethodMap());
     }
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedBETest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/entity/MannschaftsmitgliedBETest.java
@@ -1,7 +1,7 @@
 package de.bogenliga.application.business.mannschaftsmitglied.impl.entity;
 
 import org.junit.Test;
-import static de.bogenliga.application.business.mannschaftsmitglied.impl.business.MannschaftsmitgliedComponentImplTest.getMannschatfsmitgliedBE;
+import static de.bogenliga.application.business.mannschaftsmitglied.impl.business.MannschaftsmitgliedComponentImplTest.getMannschatfsmitgliedExtendedBE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -17,7 +17,7 @@ public class MannschaftsmitgliedBETest {
 
     @Test
     public void assertToString() {
-        final MannschaftsmitgliedBE underTest = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedExtendedBE underTest = getMannschatfsmitgliedExtendedBE();
         underTest.setMannschaftId(MANNSCHHAFT_ID);
         underTest.setDsbMitgliedId(DSB_MITGLIED_ID);
         underTest.setDsbMitgliedEingesetzt(DSB_MITGLIED_EINGESETZT);
@@ -36,7 +36,7 @@ public class MannschaftsmitgliedBETest {
 
     @Test
     public void assertToString_withoutMitgliedEingesetzt() {
-        final MannschaftsmitgliedBE underTest = getMannschatfsmitgliedBE();
+        final MannschaftsmitgliedBE underTest = getMannschatfsmitgliedExtendedBE();
         underTest.setMannschaftId(MANNSCHHAFT_ID);
         underTest.setDsbMitgliedId(DSB_MITGLIED_ID);
 


### PR DESCRIPTION
...durch saubere Trennung zwischen Schreiben und Lesen aus/in die Datenbank durch hinzufügen eines ExtendedBE für das Mannschaftsmitglied, welches das die MannschaftsmitgliedBE erweitert um Vor- und Nachname. Der Mapper kann nur bei lesenden Zugriffen die Informationen für das DO bereitstellen indem die erweiterte BE verwendet wird. Umgekehrt wird bei schreibenden Zugriffen vom Mapper das DO in die Basis BE umgewandelt.

Zusätzlich wurde das DTO angepasst, sodass es konsistent mit dem DTO des frontend ist.
~ MannschaftsmitgliedBE:
        - dsbMitgliedVorname, dsbMitgliedNachname
+ MannschaftsmitgliedExtendedBE: alle vererbten Methoden müssen überschrieben werden aufgrund der BasicTest-Klasse die keine vererbten Methoden erkennt!
        + dsbMitgliedVornameHat, dsbMitgliedNachname
~ MannschaftsmitgliedDAO:
        ~ columnsToFieldMap: - Vorname, Nachname
        + columnsToFieldMapExtended(): mit Vorname, Nachname
        ~find()-Methoden nutzen columnsToFieldMapExtended, geben MannschaftsmitgliedExtendedBE zurück
        ~update(), create() nutzen columnsToFieldMap, geben MannschaftsmitgliedBE zurück
        ~update Funktion sollte die id des Mannschaftsmitglied als Selektor nehmen, nicht dsbMitglied
~ MannschaftsmitgliedMapper:
        ~toMannschaftsmitgliedDO: MannschaftsmitgliedExtendedBE auf das DO
        ~toMannschaftmitgliedBE:  DO auf MannschaftsmitgliedBE
~ MannschaftsmitgliedComponentImpl: Ändern des Rückgabewertes auf ManschaftsmitgliedExtendeBE wo notwendig
~ diverse Mockings in Tests angepasst und entsprechend auf ManschaftsmitgliedExtendedBE geändert
~ diverse Refactorings wo aufgefallen!
~ MatchService.java: passeExists angepasst, sodass sie sowohl bei dem input null als auch bei nicht in der DB vorhandenen IDs richtig funktioniert
~ MatchServiceTest.java: Test an neue passeExists angepasst.