### PR TITLE
Gruppen branch bad to the bow

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
@@ -7,6 +7,7 @@ import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.dsbmannschaft.mapper.MannschaftSortierungDTOMapper;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.MannschaftSortierungDTO;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class MannschaftSortierungService implements ServiceFacade {
     @RequestMapping(method = RequestMethod.PUT,
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresPermission(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG)
+    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_STAMMDATEN, UserPermission.CAN_MODIFY_MY_VERANSTALTUNG})
     public MannschaftSortierungDTO update(@RequestBody final MannschaftSortierungDTO maSortierungDTO, final Principal principal) {
         Preconditions.checkNotNull(maSortierungDTO,PRECONDITION_MSG_DSBMANNSCHAFT_DO);
         Preconditions.checkNotNull(maSortierungDTO.getId(), PRECONDITION_MSG_DSBMANNSCHAFT_ID);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/ligatabelle/api/types/LigatabelleDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/ligatabelle/api/types/LigatabelleDO.java
@@ -163,13 +163,13 @@ public class LigatabelleDO extends CommonDataObject implements DataObject {
             return false;
         }
         final LigatabelleDO that = (LigatabelleDO) o;
-        return veranstaltungId == that.veranstaltungId &&
+        return veranstaltungId.equals(that.veranstaltungId) &&
                 Objects.equals(veranstaltungName, that.veranstaltungName)&&
-                wettkampfId ==that.wettkampfId &&
+                wettkampfId.equals(that.wettkampfId) &&
                 wettkampfTag == that.wettkampfTag &&
-                mannschaftId == that.mannschaftId &&
+                mannschaftId.equals(that.mannschaftId) &&
                 mannschaftNummer == that.mannschaftNummer &&
-                vereinId == that.vereinId &&
+                vereinId.equals(that.vereinId) &&
                 Objects.equals(vereinName, that.vereinName)&&
                 matchpkt == that.matchpkt &&
                 matchpkt_gegen == that.matchpkt_gegen &&


### PR DESCRIPTION
1. BSAPP-676 (Initialer Ligatabellen Platz kann nicht geändert werden)
Durch das hinzufügen der Zeile 54 ist es nun möglich mit dem Recht CAN_MODIFY_STAMMDATEN den Initialen Ligatabellen Platz einer Mannschaft zu ändern. Zuvor war dies nur mit dem Recht CAN_MODIFY_MY_VERANSTALTUNG möglich, weshalb man als Admin keine Änderungen vornehmen konnte.

2. Kein Ticket
Diese Änderung wurde von Intellij vorgeschlagen um die Codequalität zu steigern.