### PR TITLE
Bsapp 887

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -2,36 +2,23 @@ package de.bogenliga.application.services.v1.dsbmannschaft.service;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.bind.annotation.*;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
-import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
-import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
-import de.bogenliga.application.business.user.api.UserComponent;
-import de.bogenliga.application.business.user.api.types.UserDO;
 import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.dsbmannschaft.mapper.DsbMannschaftDTOMapper;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.DsbMannschaftDTO;
 import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
@@ -70,8 +57,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * dependency injection with {@link Autowired}
      */
     private final DsbMannschaftComponent dsbMannschaftComponent;
-    private final DsbMitgliedComponent dsbMitgliedComponent;
-    private final UserComponent userComponent;
+    private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
 
     /**
@@ -81,13 +67,9 @@ public class DsbMannschaftService implements ServiceFacade {
      */
     @Autowired
     public DsbMannschaftService(final DsbMannschaftComponent dsbMannschaftComponent,
-                                final DsbMitgliedComponent dsbMitgliedComponent,
-                                final UserComponent userComponent,
-                                final JwtTokenProvider jwtTokenProvider) {
+                                final RequiresOnePermissionAspect requiresOnePermissionAspect) {
         this.dsbMannschaftComponent = dsbMannschaftComponent;
-        this.dsbMitgliedComponent = dsbMitgliedComponent;
-        this.userComponent = userComponent;
-        this.jwtTokenProvider = jwtTokenProvider;
+        this.requiresOnePermissionAspect = requiresOnePermissionAspect;
     }
     /**
      * Autowired WebTokenProvider to get the Permissions of the current User when checking them
@@ -146,7 +128,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * @param id the given vereinsId
      * @return list of {@link DsbMannschaftDTO} as JSON
      */
-    @RequestMapping(value = "byVereinsID/{vereinsId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "byVereinsID/{vereinsId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
     public List<DsbMannschaftDTO> findAllByVereinsId(@PathVariable("vereinsId") final long id) {
         Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
@@ -164,7 +146,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * @param id the given Veranstaltungs-Id
      * @return list of {@link DsbMannschaftDTO} as JSON
      */
-    @RequestMapping(value = "byVeranstaltungsID/{veranstaltungsId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "byVeranstaltungsID/{veranstaltungsId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
     public List<DsbMannschaftDTO> findAllByVeranstaltungsId(@PathVariable("veranstaltungsId") final long id) {
         Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
@@ -191,7 +173,7 @@ public class DsbMannschaftService implements ServiceFacade {
      *
      * @return list of {@link DsbMannschaftDTO} as JSON
      */
-    @RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
     public DsbMannschaftDTO findById(@PathVariable("id") final long id) {
         Preconditions.checkArgument(id > 0, PRECONDITION_MSG_ID_NEGATIVE);
@@ -224,8 +206,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * @param principal authenticated user
      * @return list of {@link DsbMannschaftDTO} as JSON
      */
-    @RequestMapping(method = RequestMethod.POST,
-            consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresOnePermissions(perm = {UserPermission.CAN_CREATE_MANNSCHAFT,UserPermission.CAN_MODIFY_MY_VEREIN})
     public DsbMannschaftDTO create(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal) throws NoPermissionException {
@@ -233,7 +214,8 @@ public class DsbMannschaftService implements ServiceFacade {
         //Check if the User has a General Permission or,
         //check if his vereinId equals the vereinId of the mannschaft he wants to create a Team in
         //and if the user has the permission to modify his verein.
-        if(hasPermission(UserPermission.CAN_CREATE_MANNSCHAFT) || hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId())) {
+        if(this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_CREATE_MANNSCHAFT) ||
+                this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId())) {
             //if the user has the Specific Permission and the matching VereinId:
             checkPreconditions(dsbMannschaftDTO);
             final Long userId = UserProvider.getCurrentUserId(principal);
@@ -268,8 +250,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * }
      * }</pre>
      */
-    @RequestMapping(method = RequestMethod.PUT,
-            consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresOnePermissions( perm = {UserPermission.CAN_MODIFY_MANNSCHAFT, UserPermission.CAN_MODIFY_MY_VEREIN})
     public DsbMannschaftDTO update(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal) throws NoPermissionException {
@@ -277,33 +258,36 @@ public class DsbMannschaftService implements ServiceFacade {
         //Check if the User has a General Permission or,
         //check if his vereinId equals the vereinId of the mannschaft he wants to modify a Team in
         //and if the user has the permission to modify his verein.
-        if(hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT) || hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId())) {
+
+        if( !this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT) &&
+                !this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId())) {
+            throw new NoPermissionException();
+        }
             //if the My_Permission is used, the User is not allowed to change the Liga of the Mannschaft
-            if(hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId()) && !hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT)) {
-                DsbMannschaftDO dsbMannschaftDO = this.dsbMannschaftComponent.findById(dsbMannschaftDTO.getId());
-                if(!dsbMannschaftDO.getVeranstaltungId().equals(dsbMannschaftDTO.getVeranstaltungId())) {
-                    throw new NoPermissionException();
-                }
+        if(this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId()) &&
+                !this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT)) {
+            DsbMannschaftDO dsbMannschaftDO = this.dsbMannschaftComponent.findById(dsbMannschaftDTO.getId());
+            if(!dsbMannschaftDO.getVeranstaltungId().equals(dsbMannschaftDTO.getVeranstaltungId())) {
+                throw new NoPermissionException();
             }
-            checkPreconditions(dsbMannschaftDTO);
-            Preconditions.checkArgument(dsbMannschaftDTO.getId() >= 0, PRECONDITION_MSG_DSBMANNSCHAFT_ID);
+        }
+        checkPreconditions(dsbMannschaftDTO);
+        Preconditions.checkArgument(dsbMannschaftDTO.getId() >= 0, PRECONDITION_MSG_DSBMANNSCHAFT_ID);
 
-            LOG.debug(
-                    "Receive 'create' request with verein nummer '{}', mannschaft-nr '{}',  benutzer id '{}', veranstaltung id '{}',",
+        LOG.debug(
+                "Receive 'create' request with verein nummer '{}', mannschaft-nr '{}',  benutzer id '{}', veranstaltung id '{}',",
 
-                    // dsbMannschaftDTO.getId(),
-                    dsbMannschaftDTO.getVereinId(),
-                    dsbMannschaftDTO.getNummer(),
-                    dsbMannschaftDTO.getBenutzerId(),
-                    dsbMannschaftDTO.getVeranstaltungId());
+                // dsbMannschaftDTO.getId(),
+                dsbMannschaftDTO.getVereinId(),
+                dsbMannschaftDTO.getNummer(),
+                dsbMannschaftDTO.getBenutzerId(),
+                dsbMannschaftDTO.getVeranstaltungId());
 
-            final DsbMannschaftDO newDsbMannschaftDO = DsbMannschaftDTOMapper.toDO.apply(dsbMannschaftDTO);
-            final long userId = UserProvider.getCurrentUserId(principal);
+        final DsbMannschaftDO newDsbMannschaftDO = DsbMannschaftDTOMapper.toDO.apply(dsbMannschaftDTO);
+        final long userId = UserProvider.getCurrentUserId(principal);
 
-            final DsbMannschaftDO updatedDsbMannschaftDO = dsbMannschaftComponent.update(newDsbMannschaftDO,
-                    dsbMannschaftDTO.getId());
-            return DsbMannschaftDTOMapper.toDTO.apply(updatedDsbMannschaftDO);
-        } else throw new NoPermissionException();
+        final DsbMannschaftDO updatedDsbMannschaftDO = dsbMannschaftComponent.update(newDsbMannschaftDO, userId);
+        return DsbMannschaftDTOMapper.toDTO.apply(updatedDsbMannschaftDO);
     }
 
     /**
@@ -312,7 +296,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * Usage:
      * <pre>{@code Request: DELETE /v1/dsbmitglied/app.bogenliga.frontend.autorefresh.active}</pre>
      */
-    @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
+    @DeleteMapping(value = "{id}")
     @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
     public void delete(@PathVariable("id") final long id, final Principal principal) {
         Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
@@ -328,88 +312,18 @@ public class DsbMannschaftService implements ServiceFacade {
 
     private void checkPreconditions(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO) {
         Preconditions.checkNotNull(dsbMannschaftDTO, PRECONDITION_MSG_DSBMANNSCHAFT);
-        //Preconditions.checkNotNull(dsbMannschaftDTO.getId(), PRECONDITION_MSG_DSBMANNSCHAFT_ID);
         Preconditions.checkNotNull(dsbMannschaftDTO.getVereinId(), PRECONDITION_MSG_DSBMANNSCHAFT_VEREIN_ID);
         Preconditions.checkNotNull(dsbMannschaftDTO.getNummer(), PRECONDITION_MSG_DSBMANNSCHAFT_NUMMER);
         Preconditions.checkNotNull(dsbMannschaftDTO.getVeranstaltungId(), PRECONDITION_MSG_DSBMANNSCHAFT_VERANSTALTUNG_ID);
-        //Preconditions.checkNotNull(dsbMannschaftDTO.getBenutzerId(), PRECONDITION_MSG_DSBMANNSCHAFT_BENUTZER_ID);
 
 
 
-        //Preconditions.checkArgument(dsbMannschaftDTO.getId() >= 0,
-        //        PRECONDITION_MSG_DSBMANNSCHAFT_ID_NEGATIVE);
         Preconditions.checkArgument(dsbMannschaftDTO.getVereinId() >= 0,
                 PRECONDITION_MSG_DSBMANNSCHAFT_VEREIN_ID_NEGATIVE);
         Preconditions.checkArgument(dsbMannschaftDTO.getNummer() >= 0,
                 PRECONDITION_MSG_DSBMANNSCHAFT_NUMMER_NEGATIVE);
-        //Preconditions.checkArgument(dsbMannschaftDTO.getBenutzerId() >= 0,
-        //        PRECONDITION_MSG_DSBMANNSCHAFT_BENUTZER_ID_NEGATIVE);
         Preconditions.checkArgument(dsbMannschaftDTO.getVeranstaltungId() >= 0,
                 PRECONDITION_MSG_DSBMANNSCHAFT_VERANSTALTUNG_ID_NEGATIVE);
 
     }
-
-
-
-    /**
-     * method to check, if a user has a general permission
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have the searched permission
-     */
-    boolean hasPermission(UserPermission toTest) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the resolved Permissions
-                //contain the required Permission for the task.
-                if(userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * method to check, if a user has a Specific permission with the matching parameters
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have searched permission
-     */
-    boolean hasSpecificPermission(UserPermission toTest, Long vereinsId) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the current Users vereinsId equals the given vereinsId and if the User has
-                //the required Permission (if the permission is specifi
-                Long UserId = jwtTokenProvider.getUserId(jwt);
-                UserDO userDO = this.userComponent.findById(UserId);
-                DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(userDO.getDsb_mitglied_id());
-                if((dsbMitgliedDO.getVereinsId().equals(vereinsId)) && userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
@@ -2,29 +2,22 @@ package de.bogenliga.application.services.v1.dsbmitglied.service;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
 import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
-import de.bogenliga.application.business.user.api.UserComponent;
-import de.bogenliga.application.business.user.api.types.UserDO;
 import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.dsbmitglied.mapper.DsbMitgliedDTOMapper;
 import de.bogenliga.application.services.v1.dsbmitglied.model.DsbMitgliedDTO;
-import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
@@ -69,9 +62,8 @@ public class DsbMitgliedService implements ServiceFacade {
      */
     private final DsbMitgliedComponent dsbMitgliedComponent;
 
-    private final JwtTokenProvider jwtTokenProvider;
 
-    private final UserComponent userComponent;
+    private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
     /**
      * Constructor with dependency injection
@@ -80,11 +72,9 @@ public class DsbMitgliedService implements ServiceFacade {
      */
     @Autowired
     public DsbMitgliedService(final DsbMitgliedComponent dsbMitgliedComponent,
-                              final JwtTokenProvider jwtTokenProvider,
-                              final UserComponent userComponent) {
+                              final RequiresOnePermissionAspect requiresOnePermissionAspect) {
         this.dsbMitgliedComponent = dsbMitgliedComponent;
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userComponent = userComponent;
+        this.requiresOnePermissionAspect = requiresOnePermissionAspect;
     }
 
 
@@ -259,7 +249,10 @@ public class DsbMitgliedService implements ServiceFacade {
         //Check if the User has a General Permission or,
         //check if his vereinId equals the vereinId of the mannschaft he wants to create a Team in
         //and if the user has the permission to modify his verein.
-        if(hasPermission(UserPermission.CAN_CREATE_MANNSCHAFT) || hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMitgliedDTO.getVereinsId())) {
+
+        if(this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_CREATE_MANNSCHAFT)
+                || this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(
+                        UserPermission.CAN_MODIFY_MY_VEREIN, dsbMitgliedDTO.getVereinsId())) {
 
             checkPreconditions(dsbMitgliedDTO);
             Preconditions.checkArgument(dsbMitgliedDTO.getId() >= 0, PRECONDITION_MSG_DSBMITGLIED_ID);
@@ -318,69 +311,4 @@ public class DsbMitgliedService implements ServiceFacade {
         Preconditions.checkArgument(dsbMitgliedDTO.getVereinsId() >= 0,
                 PRECONDITION_MSG_DSBMITGLIED_VEREIN_ID_NEGATIVE);
     }
-
-
-
-
-    /**
-     * method to check, if a user has a general permission
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have the searched permission
-     */
-    boolean hasPermission(UserPermission toTest) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the resolved Permissions
-                //contain the required Permission for the task.
-                if(userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * method to check, if a user has a Specific permission with the matching parameters
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have searched permission
-     */
-    boolean hasSpecificPermission(UserPermission toTest, Long vereinsId) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the current Users vereinsId equals the given vereinsId and if the User has
-                //the required Permission (if the permission is specifi
-                Long UserId = jwtTokenProvider.getUserId(jwt);
-                UserDO userDO = this.userComponent.findById(UserId);
-                DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(userDO.getDsb_mitglied_id());
-                if((dsbMitgliedDO.getVereinsId() == vereinsId) && userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/kampfrichter/service/KampfrichterService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/kampfrichter/service/KampfrichterService.java
@@ -2,36 +2,27 @@ package de.bogenliga.application.services.v1.kampfrichter.service;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
-import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
+
+import de.bogenliga.application.common.service.UserProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import de.bogenliga.application.business.kampfrichter.api.KampfrichterComponent;
 import de.bogenliga.application.business.kampfrichter.api.types.KampfrichterDO;
-import de.bogenliga.application.business.user.api.UserComponent;
-import de.bogenliga.application.business.wettkampf.api.types.WettkampfDO;
 import de.bogenliga.application.common.service.ServiceFacade;
-import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.kampfrichter.model.KampfrichterDTO;
 import de.bogenliga.application.services.v1.kampfrichter.mapper.KampfrichterDTOMapper;
-import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
-import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
 
 /**
  * I´m a REST resource and handle Kampfrichter CRUD requests over the HTTP protocol.
  *
- * @author
+ * @author swt2
  * @see <a href="https://en.wikipedia.org/wiki/Create,_read,_update_and_delete">Wikipedia - CRUD</a>
  * @see <a href="https://en.wikipedia.org/wiki/Representational_state_transfer">Wikipedia - REST</a>
  * @see <a href="https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol">Wikipedia - HTTP</a>
@@ -53,17 +44,11 @@ public class KampfrichterService implements ServiceFacade {
     private static final Logger LOG = LoggerFactory.getLogger(KampfrichterService.class);
 
     private final KampfrichterComponent kampfrichterComponent;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserComponent userComponent;
 
 
     @Autowired
-    public KampfrichterService(final KampfrichterComponent kampfrichterComponent,
-                               JwtTokenProvider jwtTokenProvider,
-                               UserComponent userComponent) {
+    public KampfrichterService(final KampfrichterComponent kampfrichterComponent) {
         this.kampfrichterComponent = kampfrichterComponent;
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userComponent = userComponent;
     }
 
 
@@ -88,68 +73,16 @@ public class KampfrichterService implements ServiceFacade {
                 kampfrichterDTO.getUserID(),
                 kampfrichterDTO.getWettkampfID(),
                 kampfrichterDTO.getLeitend());
+        final long userID = UserProvider.getCurrentUserId(principal);
 
         final KampfrichterDO newKampfrichterDO = KampfrichterDTOMapper.toDO.apply(kampfrichterDTO);
 
         final KampfrichterDO savedKampfrichterDO = kampfrichterComponent.create(newKampfrichterDO,
-                newKampfrichterDO.getUserId());
+                userID);
         return KampfrichterDTOMapper.toDTO.apply(savedKampfrichterDO);
     }
 
 
-//    @RequestMapping(method = RequestMethod.PUT,
-//            consumes = MediaType.APPLICATION_JSON_VALUE,
-//            produces = MediaType.APPLICATION_JSON_VALUE)
-//    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_WETTKAMPF, UserPermission.CAN_MODIFY_MY_WETTKAMPF})
-//    public KampfrichterDTO update(@RequestBody final KampfrichterDTO kampfrichterDTO,
-//                                  final Principal principal) throws NoPermissionException {
-//        System.out.println("KAMPFRICHTER_DTO:\n" + kampfrichterDTO.toString());
-//        checkPreconditions(kampfrichterDTO);
-//
-//        LOG.debug(
-//                "Received 'update' request with userID '{}', wettkampfID '{}', leitend'{}'",
-//                kampfrichterDTO.getUserID(),
-//                kampfrichterDTO.getWettkampfID(),
-//                kampfrichterDTO.getLeitend());
-//
-////        if (this.hasPermission(UserPermission.CAN_MODIFY_WETTKAMPF) || this.hasSpecificPermission(
-////                UserPermission.CAN_MODIFY_MY_WETTKAMPF, kampfrichterDTO.getUserId())) {
-////
-////        } else {
-////            throw new NoPermissionException();
-////        }
-//        final KampfrichterDO newKampfrichterDO = KampfrichterDTOMapper.toDO.apply(kampfrichterDTO);
-//
-//        // TODO: What does this do and why do we need it?
-////        final long userId = UserProvider.getCurrentUserId(principal);
-////        System.out.println("userId:");
-////        System.out.println(userId);
-//
-//        final KampfrichterDO updatedKampfrichterDO = kampfrichterComponent.update(newKampfrichterDO,
-//                newKampfrichterDO.getUserId());
-//        return KampfrichterDTOMapper.toDTO.apply(updatedKampfrichterDO);
-//    }
-
-
-    /**
-     * Delete-Method removes an entry from the database
-     *
-     * @param userID
-     * @param principal
-     */
-//    @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-//    @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
-//    public void delete(@PathVariable("id") final long id, final Principal principal) {
-//        Preconditions.checkArgument(id >= 0, "ID must not be negative.");
-//
-//        LOG.debug("Receive 'delete' request with id '{}'", id);
-//
-//        // allow value == null, the value will be ignored
-//        final KampfrichterDO kampfrichterDO = new KampfrichterDO(id, 999L, false);
-////        final long userId = UserProvider.getCurrentUserId(principal);
-//
-//        kampfrichterComponent.delete(kampfrichterDO, id);
-//    }
 
     @DeleteMapping(value = "{userID}/{wettkampfID}")
     @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
@@ -158,71 +91,14 @@ public class KampfrichterService implements ServiceFacade {
         Preconditions.checkArgument(userID >= 0, "User-ID must not be negative.");
         Preconditions.checkArgument(wettkampfID >= 0, "Wettkampf-ID must not be negative.");
 
+        final long changeUserID = UserProvider.getCurrentUserId(principal);
         LOG.debug("Receive 'delete' request with user-ID '{}' and wettkampf-ID '{}'", userID, wettkampfID);
 
         // allow value == null, the value will be ignored
         final KampfrichterDO kampfrichterDO = new KampfrichterDO(userID, wettkampfID, false);
-//        final long userId = UserProvider.getCurrentUserId(principal);
 
-        kampfrichterComponent.delete(kampfrichterDO, userID);
+        kampfrichterComponent.delete(kampfrichterDO, changeUserID);
     }
-
-
-    boolean hasPermission(UserPermission toTest) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if (request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the resolved Permissions
-                //contain the required Permission for the task.
-                if (userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-
-//    boolean hasSpecificPermission(UserPermission toTest, Long wettkampfID) {
-//        //default value is: not allowed
-//        boolean result = false;
-//        //get the current http request from thread
-//        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-//        if (requestAttributes != null) {
-//            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-//            final HttpServletRequest request = servletRequestAttributes.getRequest();
-//            //if a request is present:
-//            if (request != null) {
-//                //parse the Webtoken and get the UserPermissions of the current User
-//                final String jwt = JwtTokenProvider.resolveToken(request);
-//                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-//
-//                //check if the current Users vereinsId equals the given vereinsId and if the User has
-//                //the required Permission (if the permission is specifi
-//                Long UserId = jwtTokenProvider.getUserId(jwt);
-//                UserDO userDO = this.userComponent.findById(UserId);
-//                ArrayList<Integer> temp = new ArrayList<>();
-//                for (WettkampfDO wettkampfDO : this.wettkampfComponent.findByAusrichter(UserId)) {
-//                    if (wettkampfDO.getId().equals(wettkampfID)) {
-//                        result = true;
-//                        break;
-//                    }
-//                }
-//
-//            }
-//        }
-//        return result;
-//    }
 
 
     private void checkPreconditions(@RequestBody final KampfrichterDTO kampfrichterDTO) {

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/service/MannschaftsMitgliedService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/service/MannschaftsMitgliedService.java
@@ -80,16 +80,6 @@ public class MannschaftsMitgliedService implements ServiceFacade {
     }
 
 
-    @GetMapping(value = "{teamIdInTeam}/{istEingesetzt}/{test3}",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
-    public List<MannschaftsMitgliedDTO> findAllSchuetzeInTeam(@PathVariable("teamIdInTeam") final long mannschaftsId) {
-        final List<MannschaftsmitgliedDO> mannschaftmitgliedDOList = mannschaftsMitgliedComponent.findAllSchuetzeInTeamEingesetzt(
-                mannschaftsId);
-        return mannschaftmitgliedDOList.stream().map(MannschaftsMitgliedDTOMapper.toDTO).collect(Collectors.toList());
-    }
-
-
     @GetMapping(value = "{memberId}/{teamId}",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
@@ -107,6 +97,17 @@ public class MannschaftsMitgliedService implements ServiceFacade {
     }
 
 
+    @GetMapping(value = "{teamIdInTeam}/{istEingesetzt}/{test3}",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
+    public List<MannschaftsMitgliedDTO> findAllSchuetzeInTeam(@PathVariable("teamIdInTeam") final long mannschaftsId) {
+        final List<MannschaftsmitgliedDO> mannschaftmitgliedDOList = mannschaftsMitgliedComponent.findAllSchuetzeInTeamEingesetzt(
+                mannschaftsId);
+        return mannschaftmitgliedDOList.stream().map(MannschaftsMitgliedDTOMapper.toDTO).collect(Collectors.toList());
+    }
+
+
+
     @GetMapping(value = "/byMemberId/{memberId}",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
@@ -117,37 +118,6 @@ public class MannschaftsMitgliedService implements ServiceFacade {
 
         final List<MannschaftsmitgliedDO> mannschaftsmitgliedDO = mannschaftsMitgliedComponent.findByMemberId(memberId);
         return mannschaftsmitgliedDO.stream().map(MannschaftsMitgliedDTOMapper.toDTO).collect(Collectors.toList());
-    }
-
-
-    @PostMapping(
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_MANNSCHAFT, UserPermission.CAN_MODIFY_MY_VEREIN})
-    public MannschaftsMitgliedDTO create(@RequestBody final MannschaftsMitgliedDTO mannschaftsMitgliedDTO,
-                                         final Principal principal) throws NoPermissionException {
-
-        checkPreconditions(mannschaftsMitgliedDTO);
-
-        LOG.debug("Receive 'create' request with mannschaftsId '{}', dsbMitgliedId '{}', DsbMitgliedEingesetzt '{}',",
-
-                mannschaftsMitgliedDTO.getMannschaftsId(),
-                mannschaftsMitgliedDTO.getDsbMitgliedId(),
-                mannschaftsMitgliedDTO.getDsbMitgliedEingesetzt());
-        long tempId = dsbMannschaftComponent.findById(mannschaftsMitgliedDTO.getMannschaftsId()).getVereinId();
-        if (!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT)
-                && !this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(
-                UserPermission.CAN_MODIFY_MY_VEREIN, tempId)) {
-            throw new NoPermissionException();
-        }
-        final MannschaftsmitgliedDO newMannschaftsmitgliedDO = MannschaftsMitgliedDTOMapper.toDO.apply(
-                mannschaftsMitgliedDTO);
-        final long currentMemberId = UserProvider.getCurrentUserId(principal);
-
-
-        final MannschaftsmitgliedDO savedMannschaftsmitgliedDO = mannschaftsMitgliedComponent.create(
-                newMannschaftsmitgliedDO, currentMemberId);
-        return MannschaftsMitgliedDTOMapper.toDTO.apply(savedMannschaftsmitgliedDO);
     }
 
 
@@ -180,6 +150,38 @@ public class MannschaftsMitgliedService implements ServiceFacade {
         return MannschaftsMitgliedDTOMapper.toDTO.apply(updatedMannschaftsmitgliedDO);
     }
 
+
+
+
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_MANNSCHAFT, UserPermission.CAN_MODIFY_MY_VEREIN})
+    public MannschaftsMitgliedDTO create(@RequestBody final MannschaftsMitgliedDTO mannschaftsMitgliedDTO,
+                                         final Principal principal) throws NoPermissionException {
+
+        checkPreconditions(mannschaftsMitgliedDTO);
+
+        LOG.debug("Receive 'create' request with mannschaftsId '{}', dsbMitgliedId '{}', DsbMitgliedEingesetzt '{}',",
+
+                mannschaftsMitgliedDTO.getMannschaftsId(),
+                mannschaftsMitgliedDTO.getDsbMitgliedId(),
+                mannschaftsMitgliedDTO.getDsbMitgliedEingesetzt());
+        long tempId = dsbMannschaftComponent.findById(mannschaftsMitgliedDTO.getMannschaftsId()).getVereinId();
+        if (!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT)
+                && !this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(
+                UserPermission.CAN_MODIFY_MY_VEREIN, tempId)) {
+            throw new NoPermissionException();
+        }
+        final MannschaftsmitgliedDO newMannschaftsmitgliedDO = MannschaftsMitgliedDTOMapper.toDO.apply(
+                mannschaftsMitgliedDTO);
+        final long currentMemberId = UserProvider.getCurrentUserId(principal);
+
+
+        final MannschaftsmitgliedDO savedMannschaftsmitgliedDO = mannschaftsMitgliedComponent.create(
+                newMannschaftsmitgliedDO, currentMemberId);
+        return MannschaftsMitgliedDTOMapper.toDTO.apply(savedMannschaftsmitgliedDO);
+    }
 
     /**
      * You are only able to delete a MannschaftsMitglied, if you have the explicit permission to Modify it or if you are

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/service/MannschaftsMitgliedService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/mannschaftsmitglied/service/MannschaftsMitgliedService.java
@@ -184,12 +184,13 @@ public class MannschaftsMitgliedService implements ServiceFacade {
     }
 
     /**
-     * You are only able to delete a MannschaftsMitglied, if you have the explicit permission to Modify it or if you are
-     * the Mannschaftsführer/Sportleiter of the Verein.
+     * You are only able to delete a MannschaftsMitglied, if you have the explicit permission
+     * Sportleiter should have a specific right to delete a single member but there is a
+     * read-vy-id function missing in MannschaftsMitgliedDAO/ MannschaftsMitgliedComponent
      **/
 
     @DeleteMapping(value = "{id}")
-    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_STAMMDATEN, UserPermission.CAN_MODIFY_MY_VEREIN})
+    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_STAMMDATEN})
     public void delete(@PathVariable("id") final long id, final Principal principal) throws NoPermissionException {
         Preconditions.checkArgument(id >= 0, "Id must not be negative.");
 
@@ -198,12 +199,6 @@ public class MannschaftsMitgliedService implements ServiceFacade {
         // allow value == null, the value will be ignored
         final MannschaftsmitgliedDO mannschaftsMitgliedDO = new MannschaftsmitgliedDO(id);
         final long currentUserId = UserProvider.getCurrentUserId(principal);
-        long tempId = dsbMannschaftComponent.findById(mannschaftsMitgliedDO.getMannschaftId()).getVereinId();
-        if (!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT)
-                && !this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(
-                UserPermission.CAN_MODIFY_MY_VEREIN, tempId)) {
-            throw new NoPermissionException();
-        }
         mannschaftsMitgliedComponent.delete(mannschaftsMitgliedDO, currentUserId);
     }
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
@@ -184,7 +184,17 @@ public class MatchService implements ServiceFacade {
 
         List<MatchDO> wettkampfMatches = matchComponent.findByWettkampfId(wettkampfid);
 
-        return wettkampfMatches.stream().map(MatchDTOMapper.toDTO).collect(Collectors.toList());
+        final List<MatchDTO> matchDTOs = new ArrayList<>();
+
+        for( MatchDO einmatch: wettkampfMatches) {
+            MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(einmatch);
+            DsbMannschaftDO mannschaftDO = mannschaftComponent.findById(matchDTO.getMannschaftId());
+            VereinDO vereinDO = vereinComponent.findById(mannschaftDO.getVereinId());
+            matchDTO.setMannschaftName(vereinDO.getName() + '-' + mannschaftDO.getNummer());
+            matchDTOs.add(matchDTO);
+        }
+
+        return matchDTOs;
     }
 
     /**
@@ -257,40 +267,6 @@ public class MatchService implements ServiceFacade {
         return matchDOList.stream().map(MatchDTOMapper.toDTO).collect(Collectors.toList());
     }
 
-    @GetMapping(value = "findAllWettkampfMatches/wettkampfid={id}",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresPermission(UserPermission.CAN_READ_WETTKAMPF)
-    public List<MatchDTO> findby(@PathVariable("id") Long wettkampfid) {
-        this.checkMatchId(wettkampfid);
-
-        List<MatchDO> wettkampfMatches = matchComponent.findByWettkampfId(wettkampfid);
-
-        return wettkampfMatches.stream().map(MatchDTOMapper.toDTO).collect(Collectors.toList());
-    }
-
-    // lesen aller Matches eines Wettkampfs und bestimmen der Namen der Mannschaften
-    @GetMapping(value = "findAllWettkampfMatchesAndName/wettkampfid={id}",
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresPermission(UserPermission.CAN_READ_WETTKAMPF)
-
-    public List<MatchDTO> findInklNameby(@PathVariable("id") Long wettkampfid) {
-
-        this.checkMatchId(wettkampfid);
-
-        List<MatchDO> wettkampfMatches = matchComponent.findByWettkampfId(wettkampfid);
-
-        final List<MatchDTO> matchDTOs = new ArrayList<>();
-
-        for( MatchDO einmatch: wettkampfMatches) {
-            MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(einmatch);
-            DsbMannschaftDO mannschaftDO = mannschaftComponent.findById(matchDTO.getMannschaftId());
-            VereinDO vereinDO = vereinComponent.findById(mannschaftDO.getVereinId());
-            matchDTO.setMannschaftName(vereinDO.getName() + '-' + mannschaftDO.getNummer());
-            matchDTOs.add(matchDTO);
-        }
-
-        return matchDTOs;
-    }
 
 
     /**

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
@@ -578,7 +578,7 @@ public class MatchService implements ServiceFacade {
                 !this.requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(
                         UserPermission.CAN_MODIFY_MY_VERANSTALTUNG, wettkampfDO.getWettkampfVeranstaltungsId())&&
                 !this.requiresOnePermissionAspect.hasSpecificPermissionAusrichter(
-                        UserPermission.CAN_MODIFY_MY_WETTKAMPF, wettkampfDO.getWettkampfTypId())) {
+                        UserPermission.CAN_MODIFY_MY_WETTKAMPF, wettkampfDO.getId())) {
             //keines der Rechte besitzt der user
             throw new NoPermissionException();
         }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
@@ -432,25 +432,6 @@ public class MatchService implements ServiceFacade {
 
 
     /**
-     * Derives the schuetzeNr from the position in the member list
-     * @param passeDTO Daten (DsbMitgliedID) des Schützen
-     * @param mannschaftsmitgliedDOS Liste der Mannshcaftsmitlgider
-     * @return Integer der Schützennummer im Team
-     */
-    public static Integer getSchuetzeNrFor(PasseDTO passeDTO, List<MannschaftsmitgliedDO> mannschaftsmitgliedDOS) {
-        int idx = 0;
-        Integer schuetzeNr = 0;
-        for (MannschaftsmitgliedDO mmdo : mannschaftsmitgliedDOS) {
-            if (mmdo.getDsbMitgliedId().equals(passeDTO.getDsbMitgliedId())) {
-                schuetzeNr = idx + 1;
-            }
-            idx++;
-        }
-        return schuetzeNr;
-    }
-
-
-    /**
      * Sucht nach dem zweiten Match einer Begegnung - das erste wird als Parameter mitgegeben
      * in der Liste aller Matches des Wettkampftages, der zugehörigen andren Scheibe und identischer Begegnungs-nr.
      * @param matchId Match zu welchem der Partner gesucht wird

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/veranstaltung/service/VeranstaltungService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/veranstaltung/service/VeranstaltungService.java
@@ -1,24 +1,15 @@
 package de.bogenliga.application.services.v1.veranstaltung.service;
 
 import java.security.Principal;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
-import org.apache.tomcat.jni.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import de.bogenliga.application.business.sportjahr.api.types.SportjahrDO;
-import de.bogenliga.application.business.user.api.UserComponent;
-import de.bogenliga.application.business.user.api.types.UserDO;
 import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
 import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
 import de.bogenliga.application.common.service.ServiceFacade;
@@ -28,7 +19,7 @@ import de.bogenliga.application.services.v1.sportjahr.SportjahrDTO;
 import de.bogenliga.application.services.v1.sportjahr.mapper.SportjahrDTOMapper;
 import de.bogenliga.application.services.v1.veranstaltung.mapper.VeranstaltungDTOMapper;
 import de.bogenliga.application.services.v1.veranstaltung.model.VeranstaltungDTO;
-import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
@@ -48,31 +39,25 @@ public class VeranstaltungService implements ServiceFacade {
     private final VeranstaltungComponent veranstaltungComponent;
 
     private static final String PRECONDITION_MSG_VERANSTALTUNG = "Veranstaltung must not be null";
-    private static final String PRECONDITION_MSG_VERANSTALTUNG_ID = "Veranstaltung Id must not be negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_NAME = "Veranstaltung Name can not be null";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_WETTKAMPFTYP_ID = "Veranstaltung Wettkampftyp id can not be negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_SPORTJARHR = "Veranstaltung Sportjahr can not be negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_MELDEDEADLINE = "Veranstaltung Meldedeadline can not be negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_LIGALEITER_ID= "Veranstaltung Ligaleiter IF id can not be negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNG_LIGA_ID= "Veranstaltung Liga id can not be negative";
-    private final  JwtTokenProvider jwtTokenProvider;
-    private final UserComponent userComponent;
+    private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
 
     /**
      * Constructor with dependency injection
      *
      * @param veranstaltungComponent to handle the database CRUD requests
-     * @param jwtTokenProvider
-     * @param userComponent
      */
     @Autowired
     public VeranstaltungService(final VeranstaltungComponent veranstaltungComponent,
-                                JwtTokenProvider jwtTokenProvider,
-                                UserComponent userComponent){
+                                RequiresOnePermissionAspect requiresOnePermissionAspect){
         this.veranstaltungComponent = veranstaltungComponent;
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userComponent = userComponent;
+        this.requiresOnePermissionAspect = requiresOnePermissionAspect;
     }
 
 
@@ -86,8 +71,8 @@ public class VeranstaltungService implements ServiceFacade {
     public List<VeranstaltungDTO> findAll(){
 
         LOG.debug("Received 'findAll' request for Veranstaltung");
-        final List<VeranstaltungDO> VeranstaltungDOList = veranstaltungComponent.findAll();
-        return VeranstaltungDOList.stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
+
+        return veranstaltungComponent.findAll().stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
     }
 
     /**
@@ -119,9 +104,9 @@ public class VeranstaltungService implements ServiceFacade {
 
         LOG.debug("Receive 'findByLigaID' with requested ID '{}'", ligaID);
 
-        final List<VeranstaltungDO> VeranstaltungDOList = veranstaltungComponent.findByLigaID(ligaID);
+        final List<VeranstaltungDO> veranstaltungDOList = veranstaltungComponent.findByLigaID(ligaID);
 
-        return VeranstaltungDOList.stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
+        return veranstaltungDOList.stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
 
     }
 
@@ -153,9 +138,8 @@ public class VeranstaltungService implements ServiceFacade {
     public List<VeranstaltungDTO> findBySportjahr(@PathVariable ("sportjahr") final long sportjahr){
 
         LOG.debug("Received 'findBySportyear' request for Veranstaltung in {}", sportjahr);
-        final List<VeranstaltungDO> VeranstaltungDOList = veranstaltungComponent.findBySportjahr(sportjahr);
 
-        return VeranstaltungDOList.stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
+        return veranstaltungComponent.findBySportjahr(sportjahr).stream().map(VeranstaltungDTOMapper.toDTO).collect(Collectors.toList());
     }
 
     /**
@@ -164,8 +148,8 @@ public class VeranstaltungService implements ServiceFacade {
      * You are only able to create a Veranstaltung, if you have the explicit permission to Create it or
      * if you are the Ligaleiter of the Veranstaltung.
      *
-     * @param veranstaltungDTO
-     * @param principal
+     * @param veranstaltungDTO die Veranstaltung die angelegt werden soll
+     * @param principal der aktuell schreibende User
      *
      * @return list of {@link VeranstaltungDTO} as JSON
      */
@@ -210,7 +194,7 @@ public class VeranstaltungService implements ServiceFacade {
                           final Principal principal) throws NoPermissionException {
 
         LOG.debug(
-                "Receive 'create' request with veranstaltungId '{}', veranstaltungName '{}', wettkampftypId '{}', sportjahr '{}', meldedeadline '{}', ligaleiterId '{}', ligaId '{}'",
+                "Receive 'update' request with veranstaltungId '{}', veranstaltungName '{}', wettkampftypId '{}', sportjahr '{}', meldedeadline '{}', ligaleiterId '{}', ligaId '{}'",
                 veranstaltungDTO.getId(),
                 veranstaltungDTO.getName(),
                 veranstaltungDTO.getWettkampfTypId(),
@@ -220,11 +204,10 @@ public class VeranstaltungService implements ServiceFacade {
                 veranstaltungDTO.getLigaId()
                 );
 
-
-
-        if(this.hasPermission(UserPermission.CAN_MODIFY_STAMMDATEN) || this.hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG,veranstaltungDTO.getId())){
-
-        }else{
+        //da die Berechtiung "modify-my-veranstaltung" abhängig ist von den Daten der Veranstaltung,
+        //ist hier nochmal zu prüfen, ob die Veranstaltung wirkling über die LigaleiterID dem User zugeordnet ist
+        if(!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+                && !this.requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG,veranstaltungDTO.getId())){
             throw new NoPermissionException();
         }
         final VeranstaltungDO newVeranstaltungDO = VeranstaltungDTOMapper.toDO.apply(veranstaltungDTO);
@@ -262,69 +245,6 @@ public class VeranstaltungService implements ServiceFacade {
         Preconditions.checkNotNull(veranstaltungDTO.getMeldeDeadline(), PRECONDITION_MSG_VERANSTALTUNG_MELDEDEADLINE);
         Preconditions.checkNotNull(veranstaltungDTO.getLigaleiterEmail(), PRECONDITION_MSG_VERANSTALTUNG_LIGALEITER_ID);
         Preconditions.checkArgument(veranstaltungDTO.getLigaId() >= 0, PRECONDITION_MSG_VERANSTALTUNG_LIGA_ID);
-    }
-    /**
-     * method to check, if a user has a general permission
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have the searched permission
-     */
-    boolean hasPermission(UserPermission toTest) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the resolved Permissions
-                //contain the required Permission for the task.
-                if(userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * method to check, if a user has a Specific permission with the matching parameters
-     * @param toTest The permission whose existence is getting checked
-     * @return Does the User have searched permission
-     */
-    boolean hasSpecificPermission(UserPermission toTest, Long veranstaltungsid) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if(request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the current Users vereinsId equals the given vereinsId and if the User has
-                //the required Permission (if the permission is specifi
-                Long UserId = jwtTokenProvider.getUserId(jwt);
-                UserDO userDO = this.userComponent.findById(UserId);
-                ArrayList<Integer> temp = new ArrayList<>();
-                for(VeranstaltungDO veranstaltungDO : this.veranstaltungComponent.findByLigaleiterId(UserId)) {
-                   if(veranstaltungDO.getVeranstaltungID() == veranstaltungsid){
-                       result = true;
-                   }
-                }
-
-            }
-        }
-        return result;
     }
 
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
@@ -42,7 +42,7 @@ public class VereineService implements ServiceFacade {
 
     private final VereinComponent vereinComponent;
 
-     private final RequiresOnePermissionAspect requiresOnePermissionAspect;
+    private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
 
     /**

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
@@ -88,6 +88,41 @@ public class VereineService implements ServiceFacade {
     }
 
     /**
+     * I persist a new verein and return this verein entry.
+     *
+     * @param vereineDTO of the request body
+     * @param principal  authenticated user
+     *
+     * @return list of {@link VereineDTO} as JSON
+     */
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresPermission(UserPermission.CAN_CREATE_STAMMDATEN)
+    public VereineDTO create(@RequestBody final VereineDTO vereineDTO, final Principal principal) {
+        checkPreconditions(vereineDTO);
+        final long userId = UserProvider.getCurrentUserId(principal);
+
+        LOG.debug(
+                "Receive 'create' request with name '{}', identifier '{}', region id '{}', website '{}', " +
+                        "description '{}', icon '{}', version '{}', createdBy '{}'",
+                vereineDTO.getName(),
+                vereineDTO.getIdentifier(),
+                vereineDTO.getRegionId(),
+                vereineDTO.getWebsite(),
+                vereineDTO.getDescription(),
+                vereineDTO.getIcon(),
+                vereineDTO.getVersion(),
+                userId);
+
+        final VereinDO vereinDO = VereineDTOMapper.toDO.apply(vereineDTO);
+        final VereinDO persistedVereinDO = vereinComponent.create(vereinDO, userId);
+
+        return VereineDTOMapper.toDTO.apply(persistedVereinDO);
+    }
+
+
+    /**
      * I persist a newer version of the dsbMitglied in the database.
      * <p>
      * You are only able to modify the Verein, if you have the explicit permission to Modify it or if you are the
@@ -144,41 +179,7 @@ public class VereineService implements ServiceFacade {
         vereinComponent.delete(vereinDO, userId);
     }
 
-    /**
-     * I persist a new verein and return this verein entry.
-     *
-     * @param vereineDTO of the request body
-     * @param principal  authenticated user
-     *
-     * @return list of {@link VereineDTO} as JSON
-     */
-    @PostMapping(
-            consumes = MediaType.APPLICATION_JSON_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresPermission(UserPermission.CAN_CREATE_STAMMDATEN)
-    public VereineDTO create(@RequestBody final VereineDTO vereineDTO, final Principal principal) {
-        checkPreconditions(vereineDTO);
-        final long userId = UserProvider.getCurrentUserId(principal);
-
-        LOG.debug(
-                "Receive 'create' request with name '{}', identifier '{}', region id '{}', website '{}', " +
-                        "description '{}', icon '{}', version '{}', createdBy '{}'",
-                vereineDTO.getName(),
-                vereineDTO.getIdentifier(),
-                vereineDTO.getRegionId(),
-                vereineDTO.getWebsite(),
-                vereineDTO.getDescription(),
-                vereineDTO.getIcon(),
-                vereineDTO.getVersion(),
-                userId);
-
-        final VereinDO vereinDO = VereineDTOMapper.toDO.apply(vereineDTO);
-        final VereinDO persistedVereinDO = vereinComponent.create(vereinDO, userId);
-
-        return VereineDTOMapper.toDTO.apply(persistedVereinDO);
-    }
-
-    private void checkPreconditions(@RequestBody final VereineDTO vereinDTO) {
+     private void checkPreconditions(@RequestBody final VereineDTO vereinDTO) {
         Preconditions.checkNotNull(vereinDTO, PRECONDITION_MSG_VEREIN);
         Preconditions.checkNotNull(vereinDTO.getName(), PRECONDITION_MSG_NAME);
         Preconditions.checkNotNull(vereinDTO.getIdentifier(), PRECONDITION_MSG_VEREIN_DSB_IDENTIFIER);

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/vereine/service/VereineService.java
@@ -2,22 +2,13 @@ package de.bogenliga.application.services.v1.vereine.service;
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.naming.NoPermissionException;
-import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
-import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
-import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
-import de.bogenliga.application.business.user.api.UserComponent;
-import de.bogenliga.application.business.user.api.types.UserDO;
 import de.bogenliga.application.business.vereine.api.VereinComponent;
 import de.bogenliga.application.business.vereine.api.types.VereinDO;
 import de.bogenliga.application.common.service.ServiceFacade;
@@ -25,7 +16,7 @@ import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.vereine.mapper.VereineDTOMapper;
 import de.bogenliga.application.services.v1.vereine.model.VereineDTO;
-import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissions;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresPermission;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
@@ -51,9 +42,7 @@ public class VereineService implements ServiceFacade {
 
     private final VereinComponent vereinComponent;
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final DsbMitgliedComponent dsbMitgliedComponent;
-    private final UserComponent userComponent;
+     private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
 
     /**
@@ -62,12 +51,10 @@ public class VereineService implements ServiceFacade {
      * @param vereinComponent to handle the database CRUD requests
      */
     @Autowired
-    public VereineService(final VereinComponent vereinComponent, final JwtTokenProvider jwtTokenProvider,
-                          final DsbMitgliedComponent dsbMitgliedComponent, final UserComponent userComponent) {
+    public VereineService(final VereinComponent vereinComponent,
+                          final RequiresOnePermissionAspect requiresOnePermissionAspect) {
         this.vereinComponent = vereinComponent;
-        this.userComponent = userComponent;
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.dsbMitgliedComponent = dsbMitgliedComponent;
+        this.requiresOnePermissionAspect = requiresOnePermissionAspect;
     }
 
     /**
@@ -126,15 +113,15 @@ public class VereineService implements ServiceFacade {
                 vereineDTO.getDescription(),
                 vereineDTO.getIcon());
 
-        if (this.hasPermissions(UserPermission.CAN_MODIFY_STAMMDATEN)) {
-        } else if (this.hasSpecificPermission(UserPermission.CAN_MODIFY_MY_VEREIN, vereineDTO.getId())) {
+        if (this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_STAMMDATEN)) {
+            //der User hat allgemeine Schreibrechte - wir machen weiter
+        } else if (this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN, vereineDTO.getId())) {
+            // der user modifiziert seinen eigenen Verein und ist Sportleiter
             VereinDO temp = vereinComponent.findById(vereineDTO.getId());
-            if (temp.getRegionId() != vereineDTO.getRegionId()) {
-                throw new NoPermissionException();
-            }
-        } else {
-            throw new NoPermissionException();
-        }
+            // das darf aber aber nur wenn der Verein in der bestehenen Region verbleibt - d.h. diese sich nicht ändert
+            if (!temp.getRegionId().equals(vereineDTO.getRegionId())) throw new NoPermissionException();
+        } else throw new NoPermissionException();
+
         final VereinDO newVereinDo = VereineDTOMapper.toDO.apply(vereineDTO);
         final long userID = UserProvider.getCurrentUserId(principal);
 
@@ -200,61 +187,4 @@ public class VereineService implements ServiceFacade {
         Preconditions.checkArgument(vereinDTO.getRegionId() >= 0, PRECONDITION_MSG_REGION_ID_NOT_NEG);
     }
 
-    /**
-     * method to check, if a user has a Specific permission with the matching parameters
-     *
-     * @param toTest The permission whose existence is getting checked
-     *
-     * @return Does the User have searched permission
-     */
-    boolean hasSpecificPermission(UserPermission toTest, Long vereinsId) {
-        //default value is: not allowed
-        boolean result = false;
-        //get the current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-            //if a request is present:
-            if (request != null) {
-                //parse the Webtoken and get the UserPermissions of the current User
-                final String jwt = JwtTokenProvider.resolveToken(request);
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-
-                //check if the current Users vereinsId equals the given vereinsId and if the User has
-                //the required Permission (if the permission is specifi
-                Long UserId = jwtTokenProvider.getUserId(jwt);
-                UserDO userDO = this.userComponent.findById(UserId);
-                DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(userDO.getDsb_mitglied_id());
-                if ((dsbMitgliedDO.getVereinsId() == vereinsId) && userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    boolean hasPermissions(UserPermission toTest) {
-        boolean result = false;
-        // get current http request from thread
-        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-        if (requestAttributes != null) {
-            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
-
-            final HttpServletRequest request = servletRequestAttributes.getRequest();
-
-            // if request present
-            if (request != null) {
-                // parse json web token with roles
-                final String jwt = JwtTokenProvider.resolveToken(request);
-
-                // custom permission check
-                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
-                if (userPermissions.contains(toTest)) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
@@ -161,6 +161,28 @@ public class WettkampfService implements ServiceFacade {
     }
 
 
+
+    /**
+     * Delete-Method removes an entry from the database
+     *
+     * @param id Datensatz zu löschen
+     * @param principal ändernder User
+     */
+    @DeleteMapping(value = "{id}")
+    @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
+    public void delete(@PathVariable("id") final long id, final Principal principal) {
+        Preconditions.checkArgument(id >= 0, "ID must not be negative.");
+
+        LOG.debug("Receive 'delete' request with id '{}'", id);
+
+        // allow value == null, the value will be ignored
+        final WettkampfDO wettkampfDO = new WettkampfDO(id);
+        final long userId = UserProvider.getCurrentUserId(principal);
+
+        wettkampfComponent.delete(wettkampfDO, userId);
+    }
+
+
     /**
      * Update-Method changes the chosen Wettkampf entry in the Database
      *
@@ -207,27 +229,6 @@ public class WettkampfService implements ServiceFacade {
 
         final WettkampfDO updatedWettkampfDO = wettkampfComponent.update(newWettkampfDO, userId);
         return WettkampfDTOMapper.toDTO.apply(updatedWettkampfDO);
-    }
-
-
-    /**
-     * Delete-Method removes an entry from the database
-     *
-     * @param id Datensatz zu löschen
-     * @param principal ändernder User
-     */
-    @DeleteMapping(value = "{id}")
-    @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
-    public void delete(@PathVariable("id") final long id, final Principal principal) {
-        Preconditions.checkArgument(id >= 0, "ID must not be negative.");
-
-        LOG.debug("Receive 'delete' request with id '{}'", id);
-
-        // allow value == null, the value will be ignored
-        final WettkampfDO wettkampfDO = new WettkampfDO(id);
-        final long userId = UserProvider.getCurrentUserId(principal);
-
-        wettkampfComponent.delete(wettkampfDO, userId);
     }
 
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
@@ -49,6 +49,7 @@ public class WettkampfService implements ServiceFacade {
     private final RequiresOnePermissionAspect requiresOnePermissionAspect;
 
 
+
     /**
      * Constructor with dependency injection
      *

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/springconfiguration/security/permissions/RequiresOnePermissionAspect.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/springconfiguration/security/permissions/RequiresOnePermissionAspect.java
@@ -1,9 +1,19 @@
 package de.bogenliga.application.springconfiguration.security.permissions;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
+
+import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
+import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
+import de.bogenliga.application.business.user.api.UserComponent;
+import de.bogenliga.application.business.user.api.types.UserDO;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
+import de.bogenliga.application.business.wettkampf.api.WettkampfComponent;
+import de.bogenliga.application.business.wettkampf.api.types.WettkampfDO;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -30,10 +40,24 @@ import de.bogenliga.application.springconfiguration.security.types.UserPermissio
 public class RequiresOnePermissionAspect {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final VeranstaltungComponent veranstaltungComponent;
+    private final DsbMitgliedComponent dsbMitgliedComponent;
+    private final UserComponent userComponent;
+    private final WettkampfComponent wettkampfComponent;
 
     @Autowired
-    public RequiresOnePermissionAspect(final JwtTokenProvider jwtTokenProvider) {
+    public RequiresOnePermissionAspect(
+            final JwtTokenProvider jwtTokenProvider,
+            final WettkampfComponent wettkampfComponent,
+            final DsbMitgliedComponent dsbMitgliedComponent,
+            final UserComponent userComponent,
+            final VeranstaltungComponent veranstaltungComponent
+            ) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.veranstaltungComponent = veranstaltungComponent;
+        this.dsbMitgliedComponent = dsbMitgliedComponent;
+        this.userComponent = userComponent;
+        this.wettkampfComponent = wettkampfComponent;
     }
 
 
@@ -91,7 +115,7 @@ public class RequiresOnePermissionAspect {
             return joinPoint.proceed();
     }
 
-    boolean hasPermission(UserPermission toTest){
+    public boolean hasPermission(UserPermission toTest){
         // get current http request from thread
         final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         boolean result = false;
@@ -116,6 +140,112 @@ public class RequiresOnePermissionAspect {
 
         return result;
     }
+
+    /**
+     * method to check, if a user has a Specific permission and
+     * when LigaLeiterID of Veranstaltung is identical to userId
+     * @param toTest The permission whose existence is getting checked
+     * @param veranstaltungsid the Veranstaltung to read
+     * @return Does the User have searched permission
+     */
+    public boolean hasSpecificPermissionLigaLeiterID(UserPermission toTest, Long veranstaltungsid) {
+        //get the current http request from thread
+        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes != null) {
+            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
+            final HttpServletRequest request = servletRequestAttributes.getRequest();
+            //if a request is present:
+            if(request != null) {
+                //parse the Webtoken and get the UserPermissions of the current User
+                final String jwt = JwtTokenProvider.resolveToken(request);
+                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
+
+                //check if the current Users vereinsId equals the given vereinsId and if the User has
+                //the required Permission (if the permission is specifi
+                // verify all jwt permissions are part of the required permissions
+                if (userPermissions.contains(toTest)) {
+                    Long userId = jwtTokenProvider.getUserId(jwt);
+                    for (VeranstaltungDO veranstaltungDO : this.veranstaltungComponent.findByLigaleiterId(userId)) {
+                        if (veranstaltungDO.getVeranstaltungID().equals(veranstaltungsid) ){
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * method to check, if a user has a Specific permission and
+     * UserId is matching the AusrichterID of the wettkampf
+     * @param toTest The permission whose existence is getting checked
+     * @param wettkampfid to check of user persmission (ausrichterId)
+     * @return Does the User have searched permission
+     */
+    public boolean hasSpecificPermissionAusrichter(UserPermission toTest, Long wettkampfid) {
+        //get the current http request from thread
+        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes != null) {
+            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
+            final HttpServletRequest request = servletRequestAttributes.getRequest();
+            //if a request is present:
+            if(request != null) {
+                //parse the Webtoken and get the UserPermissions of the current User
+                final String jwt = JwtTokenProvider.resolveToken(request);
+                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
+
+                //check if the current Users vereinsId equals the given vereinsId and if the User has
+                //the required Permission (if the permission is specifi
+                // verify all jwt permissions are part of the required permissions
+                if (userPermissions.contains(toTest)) {
+                    Long userId = jwtTokenProvider.getUserId(jwt);
+                    for (WettkampfDO wettkampfDO : this.wettkampfComponent.findByAusrichter(userId)) {
+                        if (wettkampfDO.getId().equals(wettkampfid) ) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * method to check, if a user has a Specific permission and
+     * UserId is matching the Users Verein is the same as the vereinsID
+     * @param toTest The permission whose existence is getting checked
+     * @param vereinsId to check is user is a meber of the Verein
+     * @return Does the User have searched permission
+     */
+    public boolean hasSpecificPermissionSportleiter(UserPermission toTest, Long vereinsId) {
+        //get the current http request from thread
+        final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes != null) {
+            final ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) requestAttributes;
+            final HttpServletRequest request = servletRequestAttributes.getRequest();
+            //if a request is present:
+            if (request != null) {
+                //parse the Webtoken and get the UserPermissions of the current User
+                final String jwt = JwtTokenProvider.resolveToken(request);
+                final Set<UserPermission> userPermissions = jwtTokenProvider.getPermissions(jwt);
+
+                //check if the current Users vereinsId equals the given vereinsId and if the User has
+                //the required Permission (if the permission is specifi
+                // verify all jwt permissions are part of the required permissions
+                if (userPermissions.contains(toTest)) {
+                    Long userId = jwtTokenProvider.getUserId(jwt);
+                    UserDO userDO = this.userComponent.findById(userId);
+                    DsbMitgliedDO dsbMitgliedDO = this.dsbMitgliedComponent.findById(userDO.getDsb_mitglied_id());
+                    if (dsbMitgliedDO.getVereinsId().equals(vereinsId)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     Method getCurrentMethod(final ProceedingJoinPoint joinPoint) {
         if(joinPoint == null) {
             Logger.getLogger("joinPoint is null");  //NullPointerException will be thrown

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -15,12 +15,12 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
-import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBE;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.DsbMannschaftDTO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 
 /**
  * TODO [AL] class documentation
@@ -46,6 +46,9 @@ public class DsbMannschaftServiceTest {
     private DsbMannschaftComponent dsbMannschaftComponent;
 
     @Mock
+    private RequiresOnePermissionAspect requiresOnePermissionAspect;
+
+    @Mock
     private Principal principal;
 
     @InjectMocks
@@ -55,23 +58,6 @@ public class DsbMannschaftServiceTest {
     private ArgumentCaptor<DsbMannschaftDO> dsbMannschaftVOArgumentCaptor;
 
 
-    /***
-     * Utility methods for creating business entities/data objects.
-     * Also used by other test classes.
-     */
-    public static DsbMannschaftBE getDsbMannschaftBE() {
-        final DsbMannschaftBE expectedBE = new DsbMannschaftBE();
-        // expectedBE.setDsbMannschaftId(ID);  in be fehlt set id
-        expectedBE.setId(ID);
-        expectedBE.setVereinId(VEREIN_ID);
-        expectedBE.setNummer(NUMMER);
-        expectedBE.setBenutzerId(BENUTZER_ID);
-        expectedBE.setVeranstaltungId(VERANSTALTUNG_ID);
-        expectedBE.setSortierung(SORTIERUNG);
-
-
-        return expectedBE;
-    }
 
 
     public static DsbMannschaftDO getDsbMannschaftDO() {
@@ -189,6 +175,7 @@ public class DsbMannschaftServiceTest {
 
         // configure mocks
         when(dsbMannschaftComponent.create(any(), anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
 
         // call test method
         try {
@@ -227,6 +214,7 @@ public class DsbMannschaftServiceTest {
 
         // configure mocks
         when(dsbMannschaftComponent.update(any(), anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
 
         // call test method
         try {
@@ -274,7 +262,7 @@ public class DsbMannschaftServiceTest {
 
         assertThat(deletedDsbMannschaft).isNotNull();
         assertThat(deletedDsbMannschaft.getId()).isEqualTo(expected.getId());
-        assertThat(deletedDsbMannschaft.getVereinId()).isEqualTo(null);
+        assertThat(deletedDsbMannschaft.getVereinId()).isNull();
     }
 
 }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -17,6 +17,7 @@ import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponen
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.DsbMannschaftDTO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -204,6 +205,23 @@ public class DsbMannschaftServiceTest {
         }
     }
 
+    @Test
+    public void createNoPermission() {
+        // prepare test data
+        final DsbMannschaftDTO input = getDsbMannschaftDTO();
+
+        final DsbMannschaftDO expected = getDsbMannschaftDO();
+
+        // configure mocks
+        when(dsbMannschaftComponent.create(any(), anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
+
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.create(input, principal));
+
+    }
+
 
     @Test
     public void update() {
@@ -242,6 +260,22 @@ public class DsbMannschaftServiceTest {
 
     }
 
+    @Test
+    public void updateNoPermission() {
+        // prepare test data
+        final DsbMannschaftDTO input = getDsbMannschaftDTO();
+
+        final DsbMannschaftDO expected = getDsbMannschaftDO();
+
+        // configure mocks
+        when(dsbMannschaftComponent.create(any(), anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
+
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.update(input, principal));
+
+    }
 
     @Test
     public void delete() {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
@@ -20,6 +20,7 @@ import de.bogenliga.application.business.dsbmitglied.impl.entity.DsbMitgliedBE;
 import de.bogenliga.application.services.v1.dsbmitglied.model.DsbMitgliedDTO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 
 /**
  * @author Andre Lehnert, eXXcellent solutions consulting & software gmbh
@@ -55,6 +56,9 @@ public class DsbMitgliedServiceTest {
 
     @Mock
     private Principal principal;
+
+    @Mock
+    private RequiresOnePermissionAspect requiresOnePermissionAspect;
 
     @InjectMocks
     private DsbMitgliedService underTest;
@@ -205,6 +209,7 @@ public class DsbMitgliedServiceTest {
         final DsbMitgliedDO expected = getDsbMitgliedDO();
 
         // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(dsbMitgliedComponent.update(any(), anyLong())).thenReturn(expected);
 
         // call test method

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
@@ -18,6 +18,7 @@ import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
 import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
 import de.bogenliga.application.services.v1.dsbmitglied.model.DsbMitgliedDTO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.*;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 
@@ -215,6 +216,25 @@ public class DsbMitgliedServiceTest {
 
         } catch (NoPermissionException e) {
         }
+
+    }
+
+    @Test
+    public void updateNoPermission() {
+
+        // prepare test data
+        final DsbMitgliedDTO input = getDsbMitgliedDTO();
+
+        final DsbMitgliedDO expected = getDsbMitgliedDO();
+
+        // configure mocks
+        when(dsbMitgliedComponent.update(any(), anyLong())).thenReturn(expected);
+
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
+
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.update(input, principal));
 
     }
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedServiceTest.java
@@ -16,7 +16,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
 import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
-import de.bogenliga.application.business.dsbmitglied.impl.entity.DsbMitgliedBE;
 import de.bogenliga.application.services.v1.dsbmitglied.model.DsbMitgliedDTO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -67,23 +66,6 @@ public class DsbMitgliedServiceTest {
     private ArgumentCaptor<DsbMitgliedDO> dsbMitgliedVOArgumentCaptor;
 
 
-    /***
-     * Utility methods for creating business entities/data objects.
-     * Also used by other test classes.
-     */
-    public static DsbMitgliedBE getDsbMitgliedBE() {
-        final DsbMitgliedBE expectedBE = new DsbMitgliedBE();
-        expectedBE.setDsbMitgliedId(ID);
-        expectedBE.setDsbMitgliedVorname(VORNAME);
-        expectedBE.setDsbMitgliedNachname(NACHNAME);
-        expectedBE.setDsbMitgliedGeburtsdatum(GEBURTSDATUM);
-        expectedBE.setDsbMitgliedNationalitaet(NATIONALITAET);
-        expectedBE.setDsbMitgliedMitgliedsnummer(MITGLIEDSNUMMER);
-        expectedBE.setDsbMitgliedVereinsId(VEREINSID);
-        expectedBE.setDsbMitgliedUserId(USERID);
-
-        return expectedBE;
-    }
 
 
     private static DsbMitgliedDO getDsbMitgliedDO() {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.mannschaftsmitglied.api.MannschaftsmitgliedComponent;
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
-import de.bogenliga.application.business.mannschaftsmitglied.impl.entity.MannschaftsmitgliedBE;
 import de.bogenliga.application.services.v1.mannschaftsmitglied.model.MannschaftsMitgliedDTO;
 import de.bogenliga.application.services.v1.mannschaftsmitglied.service.MannschaftsMitgliedService;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,13 +27,13 @@ import de.bogenliga.application.springconfiguration.security.permissions.Require
 public class MannschaftsmitgliedServiceTest {
 
     private static final Long USER = 0L;
-    private static Long id = 1L;
-    private static Long mannschaftsId = 1L;
-    private static Long dsbMitgliedId = 100L;
-    private static Integer dsbMitgliedEingesetzt = 1;
-    private static String dsbMitgliedVorname = "Mario";
-    private static String dsbMitgliedNachname = "Gomez";
-    private static Long rueckennummer = 5L;
+    private static final Long id = 1L;
+    private static final Long mannschaftsId = 1L;
+    private static final Long dsbMitgliedId = 100L;
+    private static final Integer dsbMitgliedEingesetzt = 1;
+    private static final String dsbMitgliedVorname = "Mario";
+    private static final String dsbMitgliedNachname = "Gomez";
+    private static final Long rueckennummer = 5L;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -54,15 +53,6 @@ public class MannschaftsmitgliedServiceTest {
     @Captor
     private ArgumentCaptor<MannschaftsmitgliedDO> mannschaftsmitgliedVOArgumentCaptor;
 
-
-    public static MannschaftsmitgliedBE getMannschaftsmitgliedBE() {
-        final MannschaftsmitgliedBE expectedBE = new MannschaftsmitgliedBE();
-        expectedBE.setMannschaftId(mannschaftsId);
-        expectedBE.setDsbMitgliedId(dsbMitgliedId);
-        expectedBE.setDsbMitgliedEingesetzt(dsbMitgliedEingesetzt);
-        expectedBE.setRueckennummer(rueckennummer);
-        return expectedBE;
-    }
 
 
     public static MannschaftsmitgliedDO getMannschaftsmitgliedDO() {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import javax.naming.NoPermissionException;
 
-import de.bogenliga.application.common.service.UserProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
+
 
 public class MannschaftsmitgliedServiceTest {
 
@@ -39,6 +41,9 @@ public class MannschaftsmitgliedServiceTest {
 
     @Mock
     private MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
+
+    @Mock
+    private RequiresOnePermissionAspect requiresOnePermissionAspect;
 
     @Mock
     private Principal principal;
@@ -175,6 +180,7 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsmitgliedDO expectedDO = getMannschaftsmitgliedDO();
 
         // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.update(any(MannschaftsmitgliedDO.class), anyLong())).thenReturn(expectedDO);
 
         // call test method
@@ -209,6 +215,7 @@ public class MannschaftsmitgliedServiceTest {
 
         final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
         // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.create(any(), anyLong())).thenReturn(expected);
 
         try {
@@ -258,6 +265,9 @@ public class MannschaftsmitgliedServiceTest {
     public void delete() {
         // prepare test data
         final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
+
+        // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
 
         // call test method
         try {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.List;
 import javax.naming.NoPermissionException;
 
+import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
+import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +46,9 @@ public class MannschaftsmitgliedServiceTest {
     private MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
 
     @Mock
+    private DsbMannschaftComponent dsbMannschaftComponent;
+
+    @Mock
     private RequiresOnePermissionAspect requiresOnePermissionAspect;
 
     @Mock
@@ -55,6 +60,13 @@ public class MannschaftsmitgliedServiceTest {
     @Captor
     private ArgumentCaptor<MannschaftsmitgliedDO> mannschaftsmitgliedVOArgumentCaptor;
 
+
+    public static DsbMannschaftDO getDsbMannschaftDO() {
+        return new DsbMannschaftDO(
+                mannschaftsId, "die Mannschaft", id, 23,
+                id, id, 2L
+        );
+    }
 
 
     public static MannschaftsmitgliedDO getMannschaftsmitgliedDO() {
@@ -168,10 +180,11 @@ public class MannschaftsmitgliedServiceTest {
     @Test
     public void update() {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
-
         final MannschaftsmitgliedDO expectedDO = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
 
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.update(any(MannschaftsmitgliedDO.class), anyLong())).thenReturn(expectedDO);
 
@@ -204,8 +217,10 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
 
         final MannschaftsmitgliedDO expectedDO = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
 
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(true);
         when(mannschaftsmitgliedComponent.update(any(MannschaftsmitgliedDO.class), anyLong())).thenReturn(expectedDO);
@@ -240,14 +255,16 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
 
         final MannschaftsmitgliedDO expectedDO = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
 
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
         when(mannschaftsmitgliedComponent.update(any(MannschaftsmitgliedDO.class), anyLong())).thenReturn(expectedDO);
 
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(NoPermissionException.class)
                 .isThrownBy(()-> underTest.create(input, principal));
     }
 
@@ -258,7 +275,10 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
 
         final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
+
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.create(any(), anyLong())).thenReturn(expected);
 
@@ -291,7 +311,10 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
 
         final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
+
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(true);
         when(mannschaftsmitgliedComponent.create(any(), anyLong())).thenReturn(expected);
@@ -325,12 +348,15 @@ public class MannschaftsmitgliedServiceTest {
         final MannschaftsMitgliedDTO input = getMannschaftsmitgliedDTO();
 
         final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
+        final DsbMannschaftDO dsbMannschaftDO = getDsbMannschaftDO();
+
         // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(dsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
         when(mannschaftsmitgliedComponent.create(any(), anyLong())).thenReturn(expected);
 
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(NoPermissionException.class)
            .isThrownBy(()-> underTest.create(input, principal));
 
     }
@@ -362,6 +388,7 @@ public class MannschaftsmitgliedServiceTest {
 
         // configure mocks
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
+        doNothing().when(mannschaftsmitgliedComponent).delete(any(), anyLong());
 
         /* call test method */
         try {
@@ -370,57 +397,11 @@ public class MannschaftsmitgliedServiceTest {
             // verify invocations
             verify(mannschaftsmitgliedComponent).delete(mannschaftsmitgliedVOArgumentCaptor.capture(), anyLong());
 
-            final MannschaftsmitgliedDO deletedDsbMitglied = mannschaftsmitgliedVOArgumentCaptor.getValue();
-
-            assertThat(deletedDsbMitglied).isNotNull();
-            assertThat(deletedDsbMitglied.getMannschaftId()).isEqualTo(expected.getMannschaftId());
-            assertThat(deletedDsbMitglied.getDsbMitgliedId()).isEqualTo(expected.getDsbMitgliedId());
-
 
         } catch (NoPermissionException | NullPointerException e) {
         }
     }
 
-    @Test
-    public void deleteDataSpecificPermission() {
-        // prepare test data
-        final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
-
-        // configure mocks
-        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
-        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(true);
-
-        /* call test method */
-        try {
-            underTest.delete(mannschaftsId, principal);
-
-            // verify invocations
-            verify(mannschaftsmitgliedComponent).delete(mannschaftsmitgliedVOArgumentCaptor.capture(), anyLong());
-
-            final MannschaftsmitgliedDO deletedDsbMitglied = mannschaftsmitgliedVOArgumentCaptor.getValue();
-
-            assertThat(deletedDsbMitglied).isNotNull();
-            assertThat(deletedDsbMitglied.getMannschaftId()).isEqualTo(expected.getMannschaftId());
-            assertThat(deletedDsbMitglied.getDsbMitgliedId()).isEqualTo(expected.getDsbMitgliedId());
-
-
-        } catch (NoPermissionException | NullPointerException e) {
-        }
-    }
-
-    @Test
-    public void deleteNoPermission() {
-        // prepare test data
-        final MannschaftsmitgliedDO expected = getMannschaftsmitgliedDO();
-
-        // configure mocks
-        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
-        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
-
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(()-> underTest.delete(mannschaftsId, principal));
-
-    }
 
 
 
@@ -432,6 +413,7 @@ public class MannschaftsmitgliedServiceTest {
 
         // configure mocks
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
+        doNothing().when(mannschaftsmitgliedComponent).deleteByTeamIdAndMemberId(any(), anyLong());
 
         // call test method
         try {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -521,6 +521,19 @@ public class MatchServiceTest {
         }
     }
 
+    @Test
+    public void createNoPermission() {
+        MatchDO matchDO1 = getMatchDO();
+        MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
+
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.create(matchDTO, principal));
+    }
+
 
     @Test
     public void create_Null() {
@@ -542,6 +555,19 @@ public class MatchServiceTest {
         MatchService.checkPreconditions(actual, MatchService.matchConditionErrors);
         } catch (NoPermissionException e) {
         }
+    }
+
+    @Test
+    public void updateNoPermission() {
+        MatchDO matchDO1 = getMatchDO();
+        MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
+
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.update(matchDTO, principal));
     }
 
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -7,16 +7,12 @@ import java.util.*;
 import javax.naming.NoPermissionException;
 
 import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
-import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
-import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
-import de.bogenliga.application.springconfiguration.security.types.UserPermission;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
@@ -37,9 +33,6 @@ import de.bogenliga.application.services.v1.match.mapper.MatchDTOMapper;
 import de.bogenliga.application.services.v1.match.model.MatchDTO;
 import de.bogenliga.application.services.v1.passe.mapper.PasseDTOMapper;
 import de.bogenliga.application.services.v1.passe.model.PasseDTO;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 
 import static java.lang.Math.toIntExact;
@@ -49,7 +42,6 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
-import java.io.*;
 
 /**
  * @author Dominik Halle, HSRT MKI SS19 - SWT2
@@ -85,9 +77,6 @@ public class MatchServiceTest {
 
     @Mock
     private MatchComponent matchComponent;
-
-    @Mock
-    private JwtTokenProvider jwtTokenProvider;
 
     @Mock
     private MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
@@ -318,9 +307,8 @@ public class MatchServiceTest {
     public void findById_Null() {
         when(matchComponent.findById(anyLong())).thenReturn(null);
         // expect a NPE as the null-state should be checked in MatchComponentImpl
-        assertThatThrownBy(() -> {
-            underTest.findById(MATCH_ID);
-        }).isInstanceOf(NullPointerException.class);
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> underTest.findById(MATCH_ID));
     }
 
 
@@ -346,10 +334,9 @@ public class MatchServiceTest {
     public void findMatchesByIds_Null() {
         when(matchComponent.findById(anyLong())).thenReturn(null);
         // expect a NPE as the null-state should be checked in MatchComponentImpl
-        assertThatThrownBy(() -> {
-            underTest.findMatchesByIds(MATCH_ID, MATCH_ID);
-        }).isInstanceOf(NullPointerException.class);
-    }
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> underTest.findMatchesByIds(MATCH_ID, MATCH_ID));
+     }
 
 
     @Test
@@ -403,10 +390,10 @@ public class MatchServiceTest {
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
 
-        assertThatThrownBy(() -> {
-            underTest.saveMatches(matches, principal);
-        }).isInstanceOf(NullPointerException.class);
-    }
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> underTest.saveMatches(matches, principal));
+
+     }
 
 
     @Test
@@ -537,10 +524,9 @@ public class MatchServiceTest {
 
     @Test
     public void create_Null() {
-        assertThatThrownBy(() -> {
-            underTest.create(null, principal);
-        }).isInstanceOf(NullPointerException.class);
-    }
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> underTest.create(null, principal));
+     }
 
 
     @Test
@@ -561,10 +547,9 @@ public class MatchServiceTest {
 
     @Test
     public void update_Null() {
-        assertThatThrownBy(() -> {
-            underTest.update(null, principal);
-        }).isInstanceOf(NullPointerException.class);
-    }
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> underTest.update(null, principal));
+     }
 
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -278,7 +278,6 @@ public class MatchServiceTest {
     @Test
     public void testFindAll() {
         MatchDO matchDO1 = getMatchDO();
-        MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
 
         ArrayList<MatchDO> matchesDO = new ArrayList<>();
         matchesDO.add(matchDO1);
@@ -583,7 +582,7 @@ public class MatchServiceTest {
         assertThat(actualDTO.getMannschaftName()).isEqualTo(matchDTO.getMannschaftName());
 
     }
-
+/*
     @Test
     public void testHasPermission() {
         // wir mocken keine statischen Aufrufe,
@@ -659,6 +658,13 @@ public class MatchServiceTest {
 
         assertTrue(underTest.hasPermission(W_id).equals(0L));
     }
-
-
+*/
+    //erst mal den OK Fall testen
+    @Test
+    public void testGetMemberIdFor() {
+        //zum testen brauchen wir eine Pass DTO mit Rückennummer eines existierenden
+        // Mannschaftsmitglieds (6 - ist das zweite Elemente der Liste)
+        PasseDTO passeDTOok = getPasseDTO(1L, 6);
+        assertEquals(MM_dsbMitgliedId, underTest.getMemberIdFor(passeDTOok, getMannschaftsMitglieder()));
+    }
 }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -660,4 +660,5 @@ public class MatchServiceTest {
         assertTrue(underTest.hasPermission(W_id).equals(0L));
     }
 
+
 }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -368,6 +368,7 @@ public class MatchServiceTest {
         matches.add(matchDTO);
         matches.add(matchDTO);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
         try {
@@ -376,6 +377,24 @@ public class MatchServiceTest {
             MatchService.checkPreconditions(actual.get(0), MatchService.matchConditionErrors);
         } catch (NoPermissionException e) {
         }
+    }
+
+    @Test
+    public void saveMatchesNoPermission() {
+        MatchDO matchDO1 = getMatchDO();
+        MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
+        ArrayList<MatchDTO> matches = new ArrayList<>();
+        matches.add(matchDTO);
+        matches.add(matchDTO);
+
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
+        when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(false);
+
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.saveMatches(matches, principal));
     }
 
 
@@ -387,6 +406,7 @@ public class MatchServiceTest {
         matches.add(null);
         matches.add(matchDTO);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
 
@@ -419,6 +439,7 @@ public class MatchServiceTest {
         matches.add(matchDTO);
         matches.add(matchDTO);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
         when(mannschaftsmitgliedComponent.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(getMannschaftsMitglieder().get(0));
@@ -458,13 +479,15 @@ public class MatchServiceTest {
 
         matchDTO.setPassen(passeDTOS);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
-        when(mannschaftsmitgliedComponent.findAllSchuetzeInTeamEingesetzt(anyLong())).thenReturn(getMannschaftsMitglieder());
+        when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
+        when(mannschaftsmitgliedComponent.findByMemberAndTeamId(anyLong(), anyLong())).thenReturn(getMannschaftsMitglieder().get(0));
 
         ArrayList<MatchDTO> matches = new ArrayList<>();
         matches.add(matchDTO);
         matches.add(matchDTO);
-        assertThatExceptionOfType(NullPointerException.class)
+        assertThatExceptionOfType(NoPermissionException.class)
                 .isThrownBy(() -> underTest.saveMatches(matches, principal));
     }
 
@@ -488,6 +511,7 @@ public class MatchServiceTest {
         matches.add(matchDTO);
         matches.add(matchDTO);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(mannschaftsmitgliedComponent.findAllSchuetzeInTeam(anyLong())).thenReturn(getMannschaftsMitglieder());
         when(mannschaftsmitgliedComponent.findByMemberAndTeamId(anyLong(),anyLong())).thenReturn(getMMDO(1L, 5L));
@@ -510,6 +534,7 @@ public class MatchServiceTest {
         MatchDO matchDO1 = getMatchDO();
         MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(matchComponent.create(any(MatchDO.class), anyLong())).thenReturn(matchDO1);
         try {
@@ -526,6 +551,7 @@ public class MatchServiceTest {
         MatchDO matchDO1 = getMatchDO();
         MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);
@@ -547,6 +573,7 @@ public class MatchServiceTest {
         MatchDO matchDO1 = getMatchDO();
         MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(matchComponent.update(any(MatchDO.class), anyLong())).thenReturn(matchDO1);
         try {
@@ -562,6 +589,7 @@ public class MatchServiceTest {
         MatchDO matchDO1 = getMatchDO();
         MatchDTO matchDTO = MatchDTOMapper.toDTO.apply(matchDO1);
 
+        when(wettkampfComponent.findById(anyLong())).thenReturn(getWettkampfDO(W_id));
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.naming.NoPermissionException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
@@ -202,6 +203,22 @@ public class VereineServiceTest {
 
         }catch (NoPermissionException e) {
         }
+    }
+
+    @Test
+    public void updateNoPermission() {
+        // prepare test data
+        final VereineDTO input = getVereineDTO();
+
+        final VereinDO expected = getVereinDO();
+
+        // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
+        when(vereinComponent.update(any(), anyLong())).thenReturn(expected);
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.update(input, principal));
+
     }
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
@@ -4,6 +4,7 @@ import de.bogenliga.application.business.vereine.api.VereinComponent;
 import de.bogenliga.application.business.vereine.api.types.VereinDO;
 import de.bogenliga.application.business.vereine.impl.entity.VereinBE;
 import de.bogenliga.application.services.v1.vereine.model.VereineDTO;
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
 import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,6 +56,9 @@ public class VereineServiceTest {
 
     @Mock
     private VereinComponent vereinComponent;
+
+    @Mock
+    private RequiresOnePermissionAspect requiresOnePermissionAspect;
 
     @Mock
     private Principal principal;
@@ -201,6 +205,7 @@ public class VereineServiceTest {
 
         // configure mocks
         when(vereinComponent.update(any(), anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
 
         try {
             // call test method

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/vereine/service/VereineServiceTest.java
@@ -2,10 +2,8 @@ package de.bogenliga.application.services.v1.vereine.service;
 
 import de.bogenliga.application.business.vereine.api.VereinComponent;
 import de.bogenliga.application.business.vereine.api.types.VereinDO;
-import de.bogenliga.application.business.vereine.impl.entity.VereinBE;
 import de.bogenliga.application.services.v1.vereine.model.VereineDTO;
 import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
-import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,8 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.security.Principal;
 import java.time.OffsetDateTime;
@@ -25,13 +21,11 @@ import java.util.List;
 
 import javax.naming.NoPermissionException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.*;
 
 public class VereineServiceTest {
 
@@ -41,16 +35,13 @@ public class VereineServiceTest {
 
     private static final String VEREIN_NAME = "";
     private static final long VEREIN_ID = 0;
-    private static final String VEREIN = "";
     private static final String VEREIN_DSB_IDENTIFIER = "";
-    private static final long REGION_ID_NOT_NEG = 0;
     private static final long REGION_ID = 0;
     private static final String REGION_NAME = "";
     private static final String VEREIN_WEBSITE = "";
     private static final String VEREIN_DESCRIPTION = "";
     private static final String VEREIN_ICON = "";
     private static final OffsetDateTime VEREIN_OFFSETDATETIME = null;
-    private static final Logger LOG = LoggerFactory.getLogger(VereineService.class);
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -69,22 +60,6 @@ public class VereineServiceTest {
     @Captor
     private ArgumentCaptor<VereinDO> vereinDOArgumentCaptor;
 
-    /***
-     * Utility methods for creating business entities/data objects.
-     * Also used by other test classes.
-     */
-    public static VereinBE getDsbMitgliedBE() {
-        final VereinBE expectedBE = new VereinBE();
-        expectedBE.setVereinId(VEREIN_ID);
-        expectedBE.setVereinName(VEREIN_NAME);
-        expectedBE.setVereinDsbIdentifier(VEREIN_DSB_IDENTIFIER);
-        expectedBE.setVereinRegionId(REGION_ID);
-        expectedBE.setVereinWebsite(VEREIN_WEBSITE);
-        expectedBE.setVereinDescription(VEREIN_DESCRIPTION);
-        expectedBE.setVereinIcon(VEREIN_ICON);
-
-        return expectedBE;
-    }
 
     public static VereinDO getVereinDO() {
         return new VereinDO(VEREIN_ID,

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
@@ -27,6 +27,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.bogenliga.application.springconfiguration.security.permissions.RequiresOnePermissionAspect;
+
 
 /**
  * Test class for Wettkampf Service
@@ -60,6 +62,10 @@ public class WettkampfServiceTest {
 
     @Mock
     private WettkampfComponent wettkampfComponent;
+
+    @Mock
+    private RequiresOnePermissionAspect requiresOnePermissionAspect;
+
 
     @Mock
     private Principal principal;
@@ -253,6 +259,7 @@ public class WettkampfServiceTest {
         final WettkampfDO expected = getWettkampfDO();
 
         // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(wettkampfComponent.update(any(), anyLong())).thenReturn(expected);
 
         try {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.naming.NoPermissionException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
@@ -260,6 +261,7 @@ public class WettkampfServiceTest {
 
         // configure mocks
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
+        when(wettkampfComponent.findById(anyLong())).thenReturn(expected);
         when(wettkampfComponent.update(any(), anyLong())).thenReturn(expected);
 
         try {
@@ -281,6 +283,22 @@ public class WettkampfServiceTest {
         } catch (NoPermissionException e) {
         }
     }
+    @Test
+    public void updateNoPermission() {
+        // prepare test data
+        final WettkampfDTO input = getWettkampfDTO();
+
+        final WettkampfDO expected = getWettkampfDO();
+
+        // configure mocks
+        when(wettkampfComponent.findById(anyLong())).thenReturn(expected);
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
+        when(requiresOnePermissionAspect.hasSpecificPermissionAusrichter(any(), anyLong())).thenReturn(false);
+
+        assertThatExceptionOfType(NoPermissionException.class)
+                .isThrownBy(()-> underTest.update(input, principal));
+
+     }
 
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/springconfiguration/security/permissions/RequiresOnePermissionAspectTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/springconfiguration/security/permissions/RequiresOnePermissionAspectTest.java
@@ -1,5 +1,6 @@
 package de.bogenliga.application.springconfiguration.security.permissions;
 
+import de.bogenliga.application.business.wettkampf.api.types.WettkampfDO;
 import de.bogenliga.application.springconfiguration.security.jsonwebtoken.JwtTokenProvider;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +24,18 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import de.bogenliga.application.business.dsbmitglied.api.DsbMitgliedComponent;
+import de.bogenliga.application.business.dsbmitglied.api.types.DsbMitgliedDO;
+import de.bogenliga.application.business.user.api.UserComponent;
+import de.bogenliga.application.business.user.api.types.UserDO;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
+import de.bogenliga.application.business.wettkampf.api.WettkampfComponent;
+import de.bogenliga.application.business.wettkampf.api.types.WettkampfDO;
+
+
+import java.sql.Date;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,8 +55,59 @@ public class RequiresOnePermissionAspectTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    private VeranstaltungComponent veranstaltungComponent;
+
+    @Mock
+    private DsbMitgliedComponent dsbMitgliedComponent;
+
+    @Mock
+    private UserComponent userComponent;
+
+    @Mock
+    private WettkampfComponent wettkampfComponent;
+
     @InjectMocks
     private RequiresOnePermissionAspect underTest;
+
+
+    private static final Long W_id = 5L;
+    private static final String W_name = "Liga_kummulativ";
+
+    private static final Long W_vid = 243L;
+    private static final Long W_typId = 0L;
+    private static final Long W_tag = 5L;
+    private static final Date W_datum = new Date(20190521L);
+    private static final String W_strasse = "Reutlingerstr. 6";
+    private static final String W_plz = "72764";
+    private static final String W_ortsname = "Reutlingen";
+    private static final String W_ortsinfo= "Hinter dem Haus";
+    private static final String W_begin = "gestern";
+    private static final Long W_disId = 12345L;
+
+    protected WettkampfDO getWettkampfDO(Long id) {
+        return new WettkampfDO(id, W_vid, W_datum, W_strasse, W_plz, W_ortsname, W_ortsinfo, W_begin, W_tag, W_disId, W_typId, null,null,null, null);
+    }
+
+    private static final Long V_id =246L;
+
+    private static final String U_email = "user@email";
+
+    protected UserDO getUserDO(Long id, Long dsb_id) {
+        UserDO userDO = new UserDO();
+        userDO.setId(id);
+        userDO.setEmail(U_email);
+        userDO.setDsb_mitglied_id(dsb_id);
+        return userDO;
+    }
+
+
+    protected DsbMitgliedDO getDsbMitgliedDO(Long dsb_id, Long vereinid) {
+        return new DsbMitgliedDO(dsb_id, "Vor-Na-Me", "Nach-Na-Me",
+                Date.valueOf("1991-09-01"), "nat", "nr", vereinid, 1L, false);
+     }
+
+
 
     @Test(expected = NullPointerException.class)
     public void checkPermission_whenRequestAttributesNull_throwNullPointerException() throws Throwable {
@@ -76,6 +140,71 @@ public class RequiresOnePermissionAspectTest {
         assertTrue(underTest.hasPermission(UserPermission.CAN_READ_DEFAULT));
         assertFalse(underTest.hasPermission(UserPermission.CAN_READ_STAMMDATEN));
 
+    }
+
+    @Test
+    public void testHasSpecificPermissionLigaLeiterID() {
+        // wir mocken keine statischen Aufrufe,
+        // sondern erzeugen uns valide Daten für das Ausführen der statischen Calls
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer testpermission");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Set<UserPermission> permissions = new HashSet<>(Arrays.asList(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG, UserPermission.CAN_CREATE_STAMMDATEN));
+        Mockito.doReturn(permissions).when(jwtTokenProvider).getPermissions("testpermission");
+        Mockito.doReturn(1L).when(jwtTokenProvider).getUserId(anyString());
+
+        VeranstaltungDO veranstaltungDO = new VeranstaltungDO();
+        veranstaltungDO.setVeranstaltungID(W_vid);
+        ArrayList<VeranstaltungDO> veranstaltungenDOS = new ArrayList<>();
+        veranstaltungenDOS.add(veranstaltungDO);
+        when(veranstaltungComponent.findByLigaleiterId(anyLong())).thenReturn(veranstaltungenDOS);
+
+        assertTrue(underTest.hasSpecificPermissionLigaLeiterID(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG,W_vid));
+        assertFalse(underTest.hasSpecificPermissionLigaLeiterID(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG,1L));
+    }
+
+    @Test
+    public void testHasSpecificPermissionAusrichter() {
+        // wir mocken keine statischen Aufrufe,
+        // sondern erzeugen uns valide Daten für das Ausführen der statischen Calls
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer testpermission");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Set<UserPermission> permissions = new HashSet<>(Arrays.asList(UserPermission.CAN_MODIFY_MY_WETTKAMPF, UserPermission.CAN_CREATE_STAMMDATEN));
+        Mockito.doReturn(permissions).when(jwtTokenProvider).getPermissions("testpermission");
+        Mockito.doReturn(1L).when(jwtTokenProvider).getUserId(anyString());
+
+        WettkampfDO wettkampfDO = getWettkampfDO(W_id);
+        ArrayList<WettkampfDO> wettkaempfeDOS = new ArrayList<>();
+        wettkaempfeDOS.add(wettkampfDO);
+
+        when(wettkampfComponent.findByAusrichter(anyLong())).thenReturn(wettkaempfeDOS);
+
+        assertTrue(underTest.hasSpecificPermissionAusrichter(UserPermission.CAN_MODIFY_MY_WETTKAMPF,W_id));
+        assertFalse(underTest.hasSpecificPermissionAusrichter(UserPermission.CAN_MODIFY_MY_WETTKAMPF,1L));
+    }
+
+    @Test
+    public void testHasSpecificPermissionSportleiter() {
+        // wir mocken keine statischen Aufrufe,
+        // sondern erzeugen uns valide Daten für das Ausführen der statischen Calls
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer testpermission");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Set<UserPermission> permissions = new HashSet<>(Arrays.asList(UserPermission.CAN_MODIFY_MY_VEREIN, UserPermission.CAN_CREATE_STAMMDATEN));
+        Mockito.doReturn(permissions).when(jwtTokenProvider).getPermissions("testpermission");
+        Mockito.doReturn(1L).when(jwtTokenProvider).getUserId(anyString());
+
+        UserDO userDO = getUserDO(55L, 1055L);
+        when(userComponent.findById(anyLong())).thenReturn(userDO);
+        DsbMitgliedDO dsbmigliedDO = getDsbMitgliedDO(1055L, V_id);
+        when(dsbMitgliedComponent.findById(anyLong())).thenReturn(dsbmigliedDO);
+
+        assertTrue(underTest.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN,V_id));
+        assertFalse(underTest.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN,1L));
     }
 
     /* TODO: Implement this test */


### PR DESCRIPTION
die in vielen Service-Interfaces im Backen implementierten und damit duplizierten Prüfen auf Datenspezifische Berechtigungen wurden in "RequiresOnePersmissionAspect" verschoben und alle Services, die das bisher lokalen hatten entsprechend angepasst. Dadurch ist eine Menge Code sowohl in den Services als auch in den zugehörigen Test entfallen - und zukünftig ist ein "Mocken" der Berechtigungsprüfung in den Services möglich ohne Wissen und Details zu "HttpRequest" o.ä. ;-)
Weiter wurden jede Menge Sonar Anmerkungen hoffentlich gefixed...