### PR TITLE
BSAPP-818 implemented

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
@@ -37,7 +37,6 @@ public class WettkampfService implements ServiceFacade {
     private static final String PRECONDITION_MSG_WETTKAMPF_STRASSE = "WettkampfStraße must not be null";
     private static final String PRECONDITION_MSG_WETTKAMPF_PLZ = "Wettkampfplz must not be null";
     private static final String PRECONDITION_MSG_WETTKAMPF_ORTSNAME = "WettkampfNamemust not be null";
-    private static final String PRECONDITION_MSG_WETTKAMPF_ORTSINFO = "WettkampfOrstinfo must not be null";
     private static final String PRECONDITION_MSG_WETTKAMPF_BEGINN = "Format: HH:MM, Format must be correct, Wettkampfbeginn must not be null";
     private static final String PRECONDITION_MSG_WETTKAMPF_TAG = "Must not be null and must not be negative";
     private static final String PRECONDITION_MSG_WETTKAMPF_DISZIPLIN_ID = "Must not be null and must not be negative";
@@ -246,8 +245,6 @@ public class WettkampfService implements ServiceFacade {
         Preconditions.checkNotNull(wettkampfDTO.getWettkampfStrasse(), PRECONDITION_MSG_WETTKAMPF_STRASSE);
         Preconditions.checkNotNull(wettkampfDTO.getWettkampfPlz(), PRECONDITION_MSG_WETTKAMPF_PLZ);
         Preconditions.checkNotNull(wettkampfDTO.getWettkampfOrtsname(), PRECONDITION_MSG_WETTKAMPF_ORTSNAME);
-        Preconditions.checkNotNull(wettkampfDTO.getWettkampfOrtsinfo(), PRECONDITION_MSG_WETTKAMPF_ORTSINFO);
-
         Preconditions.checkNotNull(wettkampfDTO.getWettkampfDisziplinId() >= 0,
                 PRECONDITION_MSG_WETTKAMPF_DISZIPLIN_ID);
         Preconditions.checkNotNull(wettkampfDTO.getwettkampfVeranstaltungsId() >= 0,
@@ -255,6 +252,4 @@ public class WettkampfService implements ServiceFacade {
         Preconditions.checkArgument(wettkampfDTO.getWettkampfTypId() >= 0, PRECONDITION_MSG_WETTKAMPF_TYP_ID);
         Preconditions.checkArgument(wettkampfDTO.getWettkampfTag() >= 0, PRECONDITION_MSG_WETTKAMPF_TAG);
     }
-
-
  }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
@@ -226,6 +226,33 @@ public class WettkampfServiceTest {
 
 
     @Test
+    public void findAllByVeranstaltungId(){
+        //prepare test data
+        final WettkampfDO wettkampfDO = getWettkampfDO();
+        final List<WettkampfDO> wettkampfDOList = Collections.singletonList(wettkampfDO);
+
+        //configure mocks
+        when(wettkampfComponent.findAllByVeranstaltungId(anyLong())).thenReturn(wettkampfDOList);
+
+        //call test method
+        final List<WettkampfDTO> actual = underTest.findAllByVeranstaltungId(wettkampf_Veranstaltung_Id);
+
+        //assert result
+        assertThat(actual)
+                .isNotNull()
+                .hasSize(1);
+
+        final WettkampfDTO actualDTO = actual.get(0);
+
+        assertThat(actualDTO).isNotNull();
+        assertThat(actualDTO.getwettkampfVeranstaltungsId()).isEqualTo(wettkampfDO.getWettkampfVeranstaltungsId());
+
+        // verify invocations
+        verify(wettkampfComponent).findAllByVeranstaltungId(wettkampf_Veranstaltung_Id);
+    }
+
+
+    @Test
     public void create() {
         // prepare test data
         final WettkampfDTO input = getWettkampfDTO();


### PR DESCRIPTION
Damit die Eingabefelder für Zusatzinfo nicht Pflicht sind (d.h. WettkampfOrtsInfo auch leer stehen darf), musste die Vorbedingung für diese Variable in WettkampfService.java entfernt werden.
Testabdeckung für Wettkampf.ServiceTest wurde leicht erhöht.

Damit wurde der Bug in BSAPP-818 beseitigt. 
Weitere Änderungswünsche zu der "Wettkampftage"-Seite werden in BSAPP-474 erläutert und momentan auch bearbeitet.