### PR TITLE
BSAPP-973

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -313,7 +313,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * <pre>{@code Request: DELETE /v1/dsbmitglied/app.bogenliga.frontend.autorefresh.active}</pre>
      */
     @DeleteMapping(value = "{id}")
-    @RequiresPermission(UserPermission.CAN_DELETE_STAMMDATEN)
+    @RequiresPermission(UserPermission.CAN_DELETE_MANNSCHAFT)
     public void delete(@PathVariable("id") final long id, final Principal principal) {
         Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
 

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V29_0__insert_roll_recht
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V29_0__insert_roll_recht
@@ -1,0 +1,7 @@
+INSERT INTO rolle_recht(
+rolle_recht_rolle_id,
+rolle_recht_recht_id
+)
+VALUES (
+2, 28
+);

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V29_0__insert_rolle_recht_ligaleiter.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V29_0__insert_rolle_recht_ligaleiter.sql
@@ -1,3 +1,4 @@
+-- Rolle Ligaleiter hat Recht CAN_DELETE_STAMMDATEN
 INSERT INTO rolle_recht(
 rolle_recht_rolle_id,
 rolle_recht_recht_id


### PR DESCRIPTION
Ligaleiter soll Mannschaften aus Veranstaltung löschen können.
Neues Skript V29 angelegt.
Abgefragte Permission zum Löschen einer Mannschaft abgeändert.
